### PR TITLE
python2 needs to be used for .xml -> .md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A Markdown file describing the standard names
 
 To regenerate the standard name Markdown file, run:
 ```
-python write_standard_name_table.py standard_names.xml
+python2 write_standard_name_table.py standard_names.xml
 ```
 
 Then, commit the new Metadata-standard-names.md file and push to GitHub.


### PR DESCRIPTION
The generic `python` will usually be interpreted as python3 now-a-days. 

Just make the README explicit.
```
python2 write_standard_name_table.py standard_names.xml
```

modified:   README.md