### PR TITLE
CAMDEN sync names with repo

### DIFF
--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -54,7 +54,7 @@ Currently, the only dimension which supports all six dimension types is horizont
     * `real(kind=kind_phys)`: units = molecules kmole-1
 * `base_state_surface_pressure_for_hybrid_vertical_coordinate`: Base state surface pressure for hybrid vertical coordinate
     * `real(kind=kind_phys)`: units = molecules kmole-1
-* `boltzman_constant`: Boltzman constant
+* `boltzmann_constant`: Boltzmann constant
     * `real(kind=kind_phys)`: units = J K-1
 * `gas_constant_of_dry_air`: Gas constant of dry air
     * `real(kind=kind_phys)`: units = J kg-1 K-1

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -80,7 +80,7 @@ Currently, the only dimension which supports all six dimension types is horizont
 * `gravitational_acceleration`: Gravitational acceleration
     * `real(kind=kind_phys)`: units = m s-2
 * `cell_area`: Cell area
-    * `real(kind=kind_phys)`: units = radian+2
+    * `real(kind=kind_phys)`: units = steradian
 * `cell_weight`: Cell weight
     * `real(kind=kind_phys)`: units = none
 ## state_variables
@@ -130,7 +130,7 @@ Note that appending '_from_previous_timestep' to standard_names in this section 
 * `reciprocal_of_pressure_thickness_of_dry_air`: Reciprocal of pressure thickness of dry air
     * `real(kind=kind_phys)`: units = Pa-1
 * `ln_of_air_pressure`: Ln of air pressure
-    * `real(kind=kind_phys)`: units = ln(Pa)
+    * `real(kind=kind_phys)`: units = 1
 * `log_of_air_pressure_of_dry_air`: Log of air pressure of dry air
     * `real(kind=kind_phys)`: units = Pa
 * `inverse_dimensionless_exner_function_wrt_surface_pressure`: inverse exner function w.r.t. surface pressure, (ps/p)^(R/cp)
@@ -144,9 +144,9 @@ Note that appending '_from_previous_timestep' to standard_names in this section 
 * `air_pressure_of_dry_air_at_interface`: Air pressure of dry air at interface
     * `real(kind=kind_phys)`: units = Pa
 * `ln_of_air_pressure_at_interface`: Ln of air pressure at interface
-    * `real(kind=kind_phys)`: units = ln(Pa)
+    * `real(kind=kind_phys)`: units = 1
 * `ln_of_air_pressure_of_dry_air_at_interface`: Ln of air pressure of dry air at interface
-    * `real(kind=kind_phys)`: units = ln(Pa)
+    * `real(kind=kind_phys)`: units = 1
 * `largest_model_top_pressure_that_allows_molecular_diffusion`: Largest model top pressure that allows molecular diffusion
     * `real(kind=kind_phys)`: units = Pa
 * `flag_for_molecular_diffusion`: Flag for molecular diffusion

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -51,9 +51,9 @@ Currently, the only dimension which supports all six dimension types is horizont
     * `integer`: units = none
 ## constants
 * `avogadro_number`: Avogadro number
-    * `real(kind=kind_phys)`: units = molecules kmole-1
+    * `real(kind=kind_phys)`: units = molecules mole-1
 * `base_state_surface_pressure_for_hybrid_vertical_coordinate`: Base state surface pressure for hybrid vertical coordinate
-    * `real(kind=kind_phys)`: units = molecules kmole-1
+    * `real(kind=kind_phys)`: units = Pa
 * `boltzmann_constant`: Boltzmann constant
     * `real(kind=kind_phys)`: units = J K-1
 * `gas_constant_of_dry_air`: Gas constant of dry air
@@ -62,12 +62,12 @@ Currently, the only dimension which supports all six dimension types is horizont
     * `integer(kind=kind_phys)`: units = s
 * `specific_heat_of_dry_air_at_constant_pressure`: Specific heat of dry air at constant pressure
     * `real(kind=kind_phys)`: units = J kg-1 K-1
-* `specific_heat_of_water_at_20c`: Specific heat of water at 20c
-    * `real(kind=kind_phys)`: units = ??????????
+* `specific_heat_of_liquid_water_at_20c`: Specific heat of liquid water at 20c
+    * `real(kind=kind_phys)`: units = J kg-1 K-1
 * `latent_heat_of_vaporization_of_water_at_0c`: latent heat of vaporization of water at 0C
     * `real(kind=kind_phys)`: units = J kg-1
 * `density_of_dry_air_at_stp`: Density of dry air at stp
-    * `None(kind=kind_phys)`: units = kg m-3
+    * `real(kind=kind_phys)`: units = kg m-3
 * `density_of_liquid_water_at_0c`: density of liquid water at 0C
     * `real(kind=kind_phys)`: units = kg m-3
 * `ratio_of_water_vapor_to_dry_air_gas_constants_minus_one`: (Rwv / Rdair) - 1.0
@@ -88,7 +88,7 @@ Note that appending '_from_previous_timestep' to standard_names in this section 
 * `physics_state_due_to_dynamics`: Physics state due to dynamics
     * `physics_state(kind=kind_phys)`: units = none
 * `timestep_for_physics`: Timestep for physics
-    * `integer(kind=kind_phys)`: units = none
+    * `integer(kind=kind_phys)`: units = s
 * `total_tendency_of_physics`: Total tendency of physics
     * `physics_tend(kind=kind_phys)`: units = none
 * `air_pressure_at_top_of_atmosphere_model`: Air pressure at top of atmosphere model
@@ -112,7 +112,7 @@ Note that appending '_from_previous_timestep' to standard_names in this section 
 * `y_wind`: Meridional wind
     * `real(kind=kind_phys)`: units = m s-1
 * `dry_static_energy`: Dry static energy Content of Atmosphere Layer
-    * `real(kind=kind_phys)`: units = J m-2
+    * `real(kind=kind_phys)`: units = J kg-1
 * `lagrangian_vertical_coordinate`: flag indicating if vertical coordinate is lagrangian
     * `logical(kind=)`: units = flag
 * `lagrangian_tendency_of_air_pressure`: Vertical pressure velocity
@@ -130,7 +130,7 @@ Note that appending '_from_previous_timestep' to standard_names in this section 
 * `reciprocal_of_pressure_thickness_of_dry_air`: Reciprocal of pressure thickness of dry air
     * `real(kind=kind_phys)`: units = Pa-1
 * `ln_of_air_pressure`: Ln of air pressure
-    * `real(kind=kind_phys)`: units = pmid
+    * `real(kind=kind_phys)`: units = ln(Pa)
 * `log_of_air_pressure_of_dry_air`: Log of air pressure of dry air
     * `real(kind=kind_phys)`: units = Pa
 * `inverse_dimensionless_exner_function_wrt_surface_pressure`: inverse exner function w.r.t. surface pressure, (ps/p)^(R/cp)
@@ -160,9 +160,9 @@ Note that appending '_from_previous_timestep' to standard_names in this section 
 * `column_integrated_total_kinetic_and_static_energy_of_current_state`: Column integrated total kinetic and static energy of current state
     * `real(kind=kind_phys)`: units = J m-2
 * `column_integrated_total_water_of_initial_state`: Column integrated total water of initial state
-    * `real(kind=kind_phys)`: units = Pa s2 m-1
+    * `real(kind=kind_phys)`: units = kg m-2
 * `column_integrated_total_water_of_new_state`: Column integrated total water of new state
-    * `real(kind=kind_phys)`: units = Pa s2 m-1
+    * `real(kind=kind_phys)`: units = kg m-2
 * `tendency_of_temperature`: Change in temperature from a parameterization
     * `real(kind=kind_phys)`: units = K s-1
 * `total_tendency_of_air_temperature`: Total change in temperature from a                               physics suite
@@ -186,13 +186,13 @@ Note that appending '_from_previous_timestep' to standard_names in this section 
 * `cumulative_boundary_flux_of_total_water`: Cumulative boundary flux of total water
     * `real(kind=kind_phys)`: units = W m-2
 * `reference_pressure`: reference pressure 
-    * `real(kind=kind_phys)`: units = mb
+    * `real(kind=kind_phys)`: units = Pa
 * `us_standard_atmospheric_pressure_at_sea_level`: US Standard Atmospheric pressure at sea level
-    * `real(kind=kind_phys)`: units = mb
+    * `real(kind=kind_phys)`: units = Pa
 * `reference_pressure_at_surface`: reference pressure at surface
-    * `real(kind=kind_phys)`: units = mb
+    * `real(kind=kind_phys)`: units = Pa
 * `reference_pressure_normalized_by_surface_pressure`: reference pressure normalized by surface pressure
-    * `real(kind=kind_phys)`: units = mb
+    * `real(kind=kind_phys)`: units = none
 * `exner_function`: exner function
     * `real(kind=kind_phys)`: units = none
 * `potential_temperature`: potential temperature

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -192,7 +192,7 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
 * `reference_pressure_normalized_by_surface_pressure`: reference pressure normalized by surface pressure
     * `real(kind=kind_phys)`: units = 1
 * `exner_function`: exner function
-    * `real(kind=kind_phys)`: units = none
+    * `real(kind=kind_phys)`: units = 1
 * `potential_temperature`: potential temperature
     * `real(kind=kind_phys)`: units = K
 * `potential_temperature_on_previous_timestep`: potential temperature on previous timestep

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -50,13 +50,23 @@ Currently, the only dimension which supports all six dimension types is horizont
 * `thread_block_index`: Number of current thread block. This variable may only be used during CCPP run phase
     * `integer`: units = none
 ## constants
-* `gas_constant_dry_air`: Gas constant dry air
+* `avogadro_number`: Avogadro number
+    * `real(kind=kind_phys)`: units = molecules kmole-1
+* `base_state_surface_pressure_for_hybrid_vertical_coordinate`: Base state surface pressure for hybrid vertical coordinate
+    * `real(kind=kind_phys)`: units = molecules kmole-1
+* `boltzman_constant`: Boltzman constant
+    * `real(kind=kind_phys)`: units = J K-1
+* `gas_constant_of_dry_air`: Gas constant of dry air
     * `real(kind=kind_phys)`: units = J kg-1 K-1
+* `seconds_in_calendar_day`: Seconds in calendar day
+    * `integer(kind=kind_phys)`: units = s
 * `specific_heat_of_dry_air_at_constant_pressure`: Specific heat of dry air at constant pressure
     * `real(kind=kind_phys)`: units = J kg-1 K-1
+* `specific_heat_of_water_at_20c`: Specific heat of water at 20c
+    * `real(kind=kind_phys)`: units = ??????????
 * `latent_heat_of_vaporization_of_water_at_0c`: latent heat of vaporization of water at 0C
     * `real(kind=kind_phys)`: units = J kg-1
-* `density_of dry_air_at_STP`: Density of dry air at STP
+* `density_of dry_air_at_stp`: Density of dry air at stp
     * `None(kind=kind_phys)`: units = kg m-3
 * `density_of_liquid_water_at_0c`: density of liquid water at 0C
     * `real(kind=kind_phys)`: units = kg m-3
@@ -69,24 +79,42 @@ Currently, the only dimension which supports all six dimension types is horizont
     * `real(kind=kind_phys)`: units = radians
 * `gravitational_acceleration`: Gravitational acceleration
     * `real(kind=kind_phys)`: units = m s-2
+* `cell_area`: Cell area
+    * `real(kind=kind_phys)`: units = radian+2
+* `cell_weight`: Cell weight
+    * `real(kind=kind_phys)`: units = none
 ## state_variables
 Note that appending '_from_previous_timestep' to standard_names in this section yields another valid standard_name
+* `physics_state_due_to_dynamics`: Physics state due to dynamics
+    * `physics_state(kind=kind_phys)`: units = none
+* `timestep_for_physics`: Timestep for physics
+    * `integer(kind=kind_phys)`: units = none
+* `total_tendency_of_physics`: Total tendency of physics
+    * `physics_tend(kind=kind_phys)`: units = none
+* `air_pressure_at_top_of_atmosphere_model`: Air pressure at top of atmosphere model
+    * `real(kind=kind_phys)`: units = Pa
+* `air_pressure_at_sea_level`: Air pressure at sea level
+    * `real(kind=kind_phys)`: units = Pa
 * `surface_air_pressure`: Surface air pressure
     * `real(kind=kind_phys)`: units = Pa
 * `surface_pressure_of_dry_air`: Surface pressure of dry air
     * `real(kind=kind_phys)`: units = Pa
 * `geopotential_at_surface`: Geopotential at surface
     * `real(kind=kind_phys)`: units = m2 s-2
-* `temperature`: Temperature
+* `air_temperature`: Air temperature
     * `real(kind=kind_phys)`: units = K
-* `temperature_from_previous_timestep`: Temperature from previous timestep
+* `air_temperature_on_previous_timestep`: Air temperature on previous timestep
     * `real(kind=kind_phys)`: units = K
-* `eastward_wind`: Zonal wind
+* `equivalent_potential_temperature`: Equivalent potential temperature
+    * `real(kind=kind_phys)`: units = K
+* `x_wind`: Zonal wind
     * `real(kind=kind_phys)`: units = m s-1
-* `northward_wind`: Meridional wind
+* `y_wind`: Meridional wind
     * `real(kind=kind_phys)`: units = m s-1
-* `dry_static_energy_content_of_atmosphere_layer`: Dry static energy
+* `dry_static_energy`: Dry static energy Content of Atmosphere Layer
     * `real(kind=kind_phys)`: units = J m-2
+* `lagrangian_vertical_coordinate`: flag indicating if vertical coordinate is lagrangian
+    * `logical(kind=)`: units = flag
 * `lagrangian_tendency_of_air_pressure`: Vertical pressure velocity
     * `real(kind=kind_phys)`: units = Pa s-1
 * `air_pressure`: Midpoint air pressure
@@ -101,11 +129,11 @@ Note that appending '_from_previous_timestep' to standard_names in this section 
     * `real(kind=kind_phys)`: units = Pa-1
 * `reciprocal_of_pressure_thickness_of_dry_air`: Reciprocal of pressure thickness of dry air
     * `real(kind=kind_phys)`: units = Pa-1
-* `natural_log_of_air_pressure`: Natural log of air pressure
+* `ln_of_air_pressure`: Ln of air pressure
     * `real(kind=kind_phys)`: units = pmid
 * `log_of_air_pressure_of_dry_air`: Log of air pressure of dry air
     * `real(kind=kind_phys)`: units = Pa
-* `inverse_exner_function_wrt_surface_pressure`: inverse exner function w.r.t. surface pressure, (ps/p)^(R/cp)
+* `inverse_dimensionless_exner_function_wrt_surface_pressure`: inverse exner function w.r.t. surface pressure, (ps/p)^(R/cp)
     * `real(kind=kind_phys)`: units = 1
 * `geopotential_height`: Geopotential height
     * `real(kind=kind_phys)`: units = m
@@ -115,35 +143,41 @@ Note that appending '_from_previous_timestep' to standard_names in this section 
     * `real(kind=kind_phys)`: units = Pa
 * `air_pressure_of_dry_air_at_interface`: Air pressure of dry air at interface
     * `real(kind=kind_phys)`: units = Pa
-* `natural_log_of_air_pressure_at_interface`: Natural log of air pressure at interface
+* `ln_of_air_pressure_at_interface`: Ln of air pressure at interface
     * `real(kind=kind_phys)`: units = ln(Pa)
-* `natural_log_of_air_pressure_of_dry_air_at_interface`: Natural log of air pressure of dry air at interface
+* `ln_of_air_pressure_of_dry_air_at_interface`: Ln of air pressure of dry air at interface
     * `real(kind=kind_phys)`: units = ln(Pa)
+* `largest_model_top_pressure_that_allows_molecular_diffusion`: Largest model top pressure that allows molecular diffusion
+    * `real(kind=kind_phys)`: units = Pa
+* `flag_for_molecular_diffusion`: Flag for molecular diffusion
+    * `logical(kind=kind_phys)`: units = flag
+* `flag_for_physics_grid_initialization`: Flag for physics grid initialization
+    * `logical(kind=kind_phys)`: units = flag
 * `geopotential_height_at_interface`: Geopotential height at interface
     * `real(kind=kind_phys)`: units = m
-* `vertically_integrated_total_kinetic_and_static_energy_of_initial_state`: Vertically integrated total kinetic and static energy of initial state
+* `column_integrated_total_kinetic_and_static_energy_of_initial_state`: Column integrated total kinetic and static energy of initial state
     * `real(kind=kind_phys)`: units = J m-2
-* `vertically_integrated_total_kinetic_and_static_energy_of_current_state`: Vertically integrated total kinetic and static energy of current state
+* `column_integrated_total_kinetic_and_static_energy_of_current_state`: Column integrated total kinetic and static energy of current state
     * `real(kind=kind_phys)`: units = J m-2
-* `vertically_integrated_total_water_of_initial_state`: Vertically integrated total water of initial state
+* `column_integrated_total_water_of_initial_state`: Column integrated total water of initial state
     * `real(kind=kind_phys)`: units = Pa s2 m-1
-* `vertically_integrated_total_water_of_new_state`: Vertically integrated total water of new state
+* `column_integrated_total_water_of_new_state`: Column integrated total water of new state
     * `real(kind=kind_phys)`: units = Pa s2 m-1
 * `tendency_of_temperature`: Change in temperature from a parameterization
     * `real(kind=kind_phys)`: units = K s-1
-* `total_tendency_of_temperature`: Total change in temperature from a                               physics suite
+* `total_tendency_of_air_temperature`: Total change in temperature from a                               physics suite
     * `real(kind=kind_phys)`: units = K s-1
 * `tendency_of_potential_temperature`: Change in potential temperature from a parameterization
     * `real(kind=kind_phys)`: units = K s-1
 * `total_tendency_of_potential_temperature`: Total tendency of potential temperature
     * `real(kind=kind_phys)`: units = K s-1
-* `tendency_of_eastward_wind`: Change in zonal wind from a parameterization
+* `tendency_of_x_wind`: Change in zonal wind from a parameterization
     * `real(kind=kind_phys)`: units = m s-2
-* `total_tendency_of_eastward_wind`: Total tendency of eastward wind
+* `total_tendency_of_x_wind`: Total tendency of x wind
     * `real(kind=kind_phys)`: units = m s-2
-* `tendency_of_northward_wind`: Change in meridional from a parameterization
+* `tendency_of_y_wind`: Change in meridional from a parameterization
     * `real(kind=kind_phys)`: units = m s-2
-* `total_tendency_of_northward_wind`: Total tendency of northward wind
+* `total_tendency_of_y_wind`: Total tendency of y wind
     * `real(kind=kind_phys)`: units = m s-2
 * `surface_energy_flux`: Surface energy flux
     * `real(kind=kind_phys)`: units = W m-2
@@ -151,11 +185,19 @@ Note that appending '_from_previous_timestep' to standard_names in this section 
     * `real(kind=kind_phys)`: units = W m-2
 * `cumulative_boundary_flux_of_total_water`: Cumulative boundary flux of total water
     * `real(kind=kind_phys)`: units = W m-2
-* `reference_pressure_at_sea_level`: reference pressure at sea level
+* `reference_pressure`: reference pressure 
+    * `real(kind=kind_phys)`: units = mb
+* `us_standard_atmospheric_pressure_at_sea_level`: US Standard Atmospheric pressure at sea level
+    * `real(kind=kind_phys)`: units = mb
+* `reference_pressure_at_surface`: reference pressure at surface
+    * `real(kind=kind_phys)`: units = mb
+* `reference_pressure_normalized_by_surface_pressure`: reference pressure normalized by surface pressure
     * `real(kind=kind_phys)`: units = mb
 * `exner_function`: exner function
     * `real(kind=kind_phys)`: units = none
 * `potential_temperature`: potential temperature
+    * `real(kind=kind_phys)`: units = K
+* `potential_temperature_on_previous_timestep`: potential temperature on previous timestep
     * `real(kind=kind_phys)`: units = K
 * `pressure_dependent_gas_constant_of_dry_air`: Pressure dependent gas constant of dry air
     * `real(kind=kind_phys)`: units = J kg-1 K-1
@@ -165,11 +207,19 @@ Note that appending '_from_previous_timestep' to standard_names in this section 
 * `total_precipitation_rate_at_surface`: Total precipitation rate at surface
     * `real(kind=kind_phys)`: units = m s-1
 ## constituents
+* `number_of_chemical_species`: Number of chemical species
+    * `integer(kind=kind_phys)`: units = count
+* `number_of_tracers`: Number of tracers
+    * `integer(kind=kind_phys)`: units = count
 * `water_vapor_specific_humidity`: Water vapor specific humidity
     * `real(kind=kind_phys)`: units = kg kg-1
 * `water_vapor_mole_fraction`: Water vapor mole fraction
     * `real(kind=kind_phys)`: units = mole mole-1
+* `cloud_liquid_water_mixing_ratio_of_moist_air`: Cloud liquid water mixing ratio of moist air
+    * `real(kind=kind_phys)`: units = kg kg-1
 * `cloud_liquid_water_mixing_ratio`: Cloud liquid water mixing ratio
+    * `real(kind=kind_phys)`: units = kg kg-1
+* `cloud_ice_mixing_ratio`: Ratio of the mass of ice to the mass of dry air
     * `real(kind=kind_phys)`: units = kg kg-1
 * `rain_water_mixing_ratio`: Rain water mixing ratio
     * `real(kind=kind_phys)`: units = kg kg-1

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -62,11 +62,11 @@ Currently, the only dimension which supports all six dimension types is horizont
     * `integer(kind=kind_phys)`: units = s
 * `specific_heat_of_dry_air_at_constant_pressure`: Specific heat of dry air at constant pressure
     * `real(kind=kind_phys)`: units = J kg-1 K-1
-* `specific_heat_of_liquid_water_at_20c`: Specific heat of liquid water at 20c
+* `specific_heat_of_liquid_water_at_20c`: specific heat of liquid water at 20C
     * `real(kind=kind_phys)`: units = J kg-1 K-1
 * `latent_heat_of_vaporization_of_water_at_0c`: latent heat of vaporization of water at 0C
     * `real(kind=kind_phys)`: units = J kg-1
-* `density_of_dry_air_at_stp`: Density of dry air at stp
+* `density_of_dry_air_at_stp`: density of dry air at STP
     * `real(kind=kind_phys)`: units = kg m-3
 * `density_of_liquid_water_at_0c`: density of liquid water at 0C
     * `real(kind=kind_phys)`: units = kg m-3
@@ -84,7 +84,7 @@ Currently, the only dimension which supports all six dimension types is horizont
 * `cell_weight`: Cell weight
     * `real(kind=kind_phys)`: units = none
 ## state_variables
-Note that appending '_from_previous_timestep' to standard_names in this section yields another valid standard_name
+Note that appending '_on_previous_timestep' to standard_names in this section yields another valid standard_name
 * `physics_state_due_to_dynamics`: Physics state due to dynamics
     * `physics_state(kind=kind_phys)`: units = none
 * `timestep_for_physics`: Timestep for physics
@@ -151,7 +151,7 @@ Note that appending '_from_previous_timestep' to standard_names in this section 
     * `real(kind=kind_phys)`: units = Pa
 * `flag_for_molecular_diffusion`: Flag for molecular diffusion
     * `logical(kind=kind_phys)`: units = flag
-* `flag_for_physics_grid_initialization`: Flag for physics grid initialization
+* `flag_for_physics_grid_initialization`: Flag to indicate if physics grid is initialized
     * `logical(kind=kind_phys)`: units = flag
 * `geopotential_height_at_interface`: Geopotential height at interface
     * `real(kind=kind_phys)`: units = m
@@ -161,7 +161,7 @@ Note that appending '_from_previous_timestep' to standard_names in this section 
     * `real(kind=kind_phys)`: units = J m-2
 * `column_integrated_total_water_of_initial_state`: Column integrated total water of initial state
     * `real(kind=kind_phys)`: units = kg m-2
-* `column_integrated_total_water_of_new_state`: Column integrated total water of new state
+* `column_integrated_total_water_of_current_state`: Column integrated total water of current state
     * `real(kind=kind_phys)`: units = kg m-2
 * `tendency_of_temperature`: Change in temperature from a parameterization
     * `real(kind=kind_phys)`: units = K s-1
@@ -192,7 +192,7 @@ Note that appending '_from_previous_timestep' to standard_names in this section 
 * `reference_pressure_at_surface`: reference pressure at surface
     * `real(kind=kind_phys)`: units = Pa
 * `reference_pressure_normalized_by_surface_pressure`: reference pressure normalized by surface pressure
-    * `real(kind=kind_phys)`: units = none
+    * `real(kind=kind_phys)`: units = 1
 * `exner_function`: exner function
     * `real(kind=kind_phys)`: units = none
 * `potential_temperature`: potential temperature

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -213,7 +213,7 @@ Note that appending '_from_previous_timestep' to standard_names in this section 
     * `integer(kind=kind_phys)`: units = count
 * `water_vapor_specific_humidity`: Water vapor specific humidity
     * `real(kind=kind_phys)`: units = kg kg-1
-* `water_vapor_mole_fraction`: Water vapor mole fraction
+* `mole_fraction_of_water_vapor`: Mole fraction of water vapor
     * `real(kind=kind_phys)`: units = mole mole-1
 * `cloud_liquid_water_mixing_ratio_of_moist_air`: Cloud liquid water mixing ratio of moist air
     * `real(kind=kind_phys)`: units = kg kg-1

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -66,7 +66,7 @@ Currently, the only dimension which supports all six dimension types is horizont
     * `real(kind=kind_phys)`: units = ??????????
 * `latent_heat_of_vaporization_of_water_at_0c`: latent heat of vaporization of water at 0C
     * `real(kind=kind_phys)`: units = J kg-1
-* `density_of dry_air_at_stp`: Density of dry air at stp
+* `density_of_dry_air_at_stp`: Density of dry air at stp
     * `None(kind=kind_phys)`: units = kg m-3
 * `density_of_liquid_water_at_0c`: density of liquid water at 0C
     * `real(kind=kind_phys)`: units = kg m-3

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -105,11 +105,9 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = K
 * `air_temperature_on_previous_timestep`: Air temperature on previous timestep
     * `real(kind=kind_phys)`: units = K
-* `equivalent_potential_temperature`: Equivalent potential temperature
-    * `real(kind=kind_phys)`: units = K
-* `x_wind`: Zonal wind
+* `x_wind`: Horizontal wind in a direction perdendicular to y_wind
     * `real(kind=kind_phys)`: units = m s-1
-* `y_wind`: Meridional wind
+* `y_wind`: Horizontal wind in a direction perdendicular to x_wind
     * `real(kind=kind_phys)`: units = m s-1
 * `dry_static_energy`: Dry static energy Content of Atmosphere Layer
     * `real(kind=kind_phys)`: units = J kg-1
@@ -171,11 +169,11 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = K s-1
 * `total_tendency_of_potential_temperature`: Total tendency of potential temperature
     * `real(kind=kind_phys)`: units = K s-1
-* `tendency_of_x_wind`: Change in zonal wind from a parameterization
+* `tendency_of_x_wind`: Change in x wind from a parameterization
     * `real(kind=kind_phys)`: units = m s-2
 * `total_tendency_of_x_wind`: Total tendency of x wind
     * `real(kind=kind_phys)`: units = m s-2
-* `tendency_of_y_wind`: Change in meridional from a parameterization
+* `tendency_of_y_wind`: Change in y wind from a parameterization
     * `real(kind=kind_phys)`: units = m s-2
 * `total_tendency_of_y_wind`: Total tendency of y wind
     * `real(kind=kind_phys)`: units = m s-2

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -131,7 +131,7 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = 1
 * `log_of_air_pressure_of_dry_air`: Log of air pressure of dry air
     * `real(kind=kind_phys)`: units = Pa
-* `inverse_dimensionless_exner_function_wrt_surface_pressure`: inverse exner function w.r.t. surface pressure, (ps/p)^(R/cp)
+* `inverse_exner_function_wrt_surface_pressure`: inverse exner function w.r.t. surface pressure, (ps/p)^(R/cp)
     * `real(kind=kind_phys)`: units = 1
 * `geopotential_height`: Geopotential height
     * `real(kind=kind_phys)`: units = m

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -74,17 +74,32 @@
     </standard_name>
   </section>
   <section name="constants">
-    <standard_name name="gas_constant_dry_air">
+    <standard_name name="avogadro_number">
+      <type kind="kind_phys" units="molecules kmole-1">real</type>
+    </standard_name>
+    <standard_name name="base_state_surface_pressure_for_hybrid_vertical_coordinate">
+      <type kind="kind_phys" units="molecules kmole-1">real</type>
+    </standard_name>
+    <standard_name name="boltzman_constant">
+      <type kind="kind_phys" units="J K-1">real</type>
+    </standard_name>
+    <standard_name name="gas_constant_of_dry_air">
       <type kind="kind_phys" units="J kg-1 K-1">real</type>
+    </standard_name>
+    <standard_name name="seconds_in_calendar_day">
+      <type kind="kind_phys" units="s">integer</type>
     </standard_name>
     <standard_name name="specific_heat_of_dry_air_at_constant_pressure">
       <type kind="kind_phys" units="J kg-1 K-1">real</type>
+    </standard_name>
+    <standard_name name="specific_heat_of_water_at_20c">
+      <type kind="kind_phys" units="??????????">real</type>
     </standard_name>
     <standard_name name="latent_heat_of_vaporization_of_water_at_0c"
                    long_name="latent heat of vaporization of water at 0C">
       <type kind="kind_phys" units="J kg-1">real</type>
     </standard_name>
-    <standard_name name="density_of dry_air_at_STP">
+    <standard_name name="density_of dry_air_at_stp">
       <type kind="kind_phys" units="kg m-3"></type>
     </standard_name>
     <standard_name name="density_of_liquid_water_at_0c"
@@ -107,9 +122,30 @@
     <standard_name name="gravitational_acceleration">
       <type kind="kind_phys" units="m s-2">real</type>
     </standard_name>
+    <standard_name name="cell_area">
+      <type kind="kind_phys" units="radian+2">real</type>
+    </standard_name>
+    <standard_name name="cell_weight">
+      <type kind="kind_phys" units="none">real</type>
+    </standard_name>
   </section>
   <section name="state_variables"
            comment="Note that appending '_from_previous_timestep' to standard_names in this section yields another valid standard_name">
+    <standard_name name="physics_state_due_to_dynamics">
+      <type kind="kind_phys" units="none">physics_state</type>
+    </standard_name>
+    <standard_name name="timestep_for_physics">
+      <type kind="kind_phys" units="none">integer</type>
+    </standard_name>
+    <standard_name name="total_tendency_of_physics">
+      <type kind="kind_phys" units="none">physics_tend</type>
+    </standard_name>
+    <standard_name name="air_pressure_at_top_of_atmosphere_model">
+      <type kind="kind_phys" units="Pa">real</type>
+    </standard_name>
+    <standard_name name="air_pressure_at_sea_level">
+      <type kind="kind_phys" units="Pa">real</type>
+    </standard_name>
     <standard_name name="surface_air_pressure">
       <type kind="kind_phys" units="Pa">real</type>
     </standard_name>
@@ -119,23 +155,31 @@
     <standard_name name="geopotential_at_surface">
       <type kind="kind_phys" units="m2 s-2">real</type>
     </standard_name>
-    <standard_name name="temperature">
+    <standard_name name="air_temperature">
       <type kind="kind_phys" units="K">real</type>
     </standard_name>
-    <standard_name name="temperature_from_previous_timestep">
+    <standard_name name="air_temperature_on_previous_timestep">
       <type kind="kind_phys" units="K">real</type>
     </standard_name>
-    <standard_name name="eastward_wind"
+    </standard_name>
+    <standard_name name="equivalent_potential_temperature">
+      <type kind="kind_phys" units="K">real</type>
+    </standard_name>
+    <standard_name name="x_wind"
                    long_name="Zonal wind">
       <type kind="kind_phys" units="m s-1">real</type>
     </standard_name>
-    <standard_name name="northward_wind"
+    <standard_name name="y_wind"
                    long_name="Meridional wind">
       <type kind="kind_phys" units="m s-1">real</type>
     </standard_name>
-    <standard_name name="dry_static_energy_content_of_atmosphere_layer"
-                   long_name="Dry static energy">
+    <standard_name name="dry_static_energy"
+                   long_name="Dry static energy Content of Atmosphere Layer">
       <type kind="kind_phys" units="J m-2">real</type>
+    </standard_name>
+    <standard_name name="lagrangian_vertical_coordinate"
+                   long_name="flag indicating if vertical coordinate is lagrangian">
+      <type kind="" units="flag">logical</type>
     </standard_name>
     <standard_name name="lagrangian_tendency_of_air_pressure"
                    long_name="Vertical pressure velocity">
@@ -161,13 +205,13 @@
     <standard_name name="reciprocal_of_pressure_thickness_of_dry_air">
       <type kind="kind_phys" units="Pa-1">real</type>
     </standard_name>
-    <standard_name name="natural_log_of_air_pressure">
+    <standard_name name="ln_of_air_pressure">
       <type kind="kind_phys" units="pmid">real</type>
     </standard_name>
     <standard_name name="log_of_air_pressure_of_dry_air">
       <type kind="kind_phys" units="Pa">real</type>
     </standard_name>
-    <standard_name name="inverse_exner_function_wrt_surface_pressure"
+    <standard_name name="inverse_dimensionless_exner_function_wrt_surface_pressure"
                    long_name="inverse exner function w.r.t. surface pressure, (ps/p)^(R/cp)">
       <type kind="kind_phys" units="1">real</type>
     </standard_name>
@@ -183,32 +227,41 @@
     <standard_name name="air_pressure_of_dry_air_at_interface">
       <type kind="kind_phys" units="Pa">real</type>
     </standard_name>
-    <standard_name name="natural_log_of_air_pressure_at_interface">
+    <standard_name name="ln_of_air_pressure_at_interface">
       <type kind="kind_phys" units="ln(Pa)">real</type>
     </standard_name>
-    <standard_name name="natural_log_of_air_pressure_of_dry_air_at_interface">
+    <standard_name name="ln_of_air_pressure_of_dry_air_at_interface">
       <type kind="kind_phys" units="ln(Pa)">real</type>
+    </standard_name>
+    <standard_name name="largest_model_top_pressure_that_allows_molecular_diffusion">
+      <type kind="kind_phys" units="Pa">real</type>
+    </standard_name>
+    <standard_name name="flag_for_molecular_diffusion">
+      <type kind="kind_phys" units="flag">logical</type>
+    </standard_name>
+    <standard_name name="flag_for_physics_grid_initialization">
+      <type kind="kind_phys" units="flag">logical</type>
     </standard_name>
     <standard_name name="geopotential_height_at_interface">
       <type kind="kind_phys" units="m">real</type>
     </standard_name>
-    <standard_name name="vertically_integrated_total_kinetic_and_static_energy_of_initial_state">
+    <standard_name name="column_integrated_total_kinetic_and_static_energy_of_initial_state">
       <type kind="kind_phys" units="J m-2">real</type>
     </standard_name>
-    <standard_name name="vertically_integrated_total_kinetic_and_static_energy_of_current_state">
+    <standard_name name="column_integrated_total_kinetic_and_static_energy_of_current_state">
       <type kind="kind_phys" units="J m-2">real</type>
     </standard_name>
-    <standard_name name="vertically_integrated_total_water_of_initial_state">
+    <standard_name name="column_integrated_total_water_of_initial_state">
       <type kind="kind_phys" units="Pa s2 m-1">real</type>
     </standard_name>
-    <standard_name name="vertically_integrated_total_water_of_new_state">
+    <standard_name name="column_integrated_total_water_of_new_state">
       <type kind="kind_phys" units="Pa s2 m-1">real</type>
     </standard_name>
     <standard_name name="tendency_of_temperature"
                    long_name="Change in temperature from a parameterization">
       <type kind="kind_phys" units="K s-1">real</type>
     </standard_name>
-    <standard_name name="total_tendency_of_temperature"
+    <standard_name name="total_tendency_of_air_temperature"
                    long_name="Total change in temperature from a
                               physics suite">
       <type kind="kind_phys" units="K s-1">real</type>
@@ -220,18 +273,18 @@
     <standard_name name="total_tendency_of_potential_temperature">
       <type kind="kind_phys" units="K s-1">real</type>
     </standard_name>
-    <standard_name name="tendency_of_eastward_wind"
+    <standard_name name="tendency_of_x_wind"
                    long_name="Change in zonal wind from a parameterization">
       <type kind="kind_phys" units="m s-2">real</type>
     </standard_name>
-    <standard_name name="total_tendency_of_eastward_wind">
+    <standard_name name="total_tendency_of_x_wind">
       <type kind="kind_phys" units="m s-2">real</type>
     </standard_name>
-    <standard_name name="tendency_of_northward_wind"
+    <standard_name name="tendency_of_y_wind"
                    long_name="Change in meridional from a parameterization">
       <type kind="kind_phys" units="m s-2">real</type>
     </standard_name>
-    <standard_name name="total_tendency_of_northward_wind">
+    <standard_name name="total_tendency_of_y_wind">
       <type kind="kind_phys" units="m s-2">real</type>
     </standard_name>
     <standard_name name="surface_energy_flux">
@@ -243,8 +296,20 @@
     <standard_name name="cumulative_boundary_flux_of_total_water">
       <type kind="kind_phys" units="W m-2">real</type>
     </standard_name>
-    <standard_name name="reference_pressure_at_sea_level"
-                   long_name="reference pressure at sea level">
+    <standard_name name="reference_pressure"
+                   long_name="reference pressure ">
+      <type kind="kind_phys" units="mb">real</type>
+    </standard_name>
+    <standard_name name="us_standard_atmospheric_pressure_at_sea_level"
+                   long_name="US Standard Atmospheric pressure at sea level">
+      <type kind="kind_phys" units="mb">real</type>
+    </standard_name>
+    <standard_name name="reference_pressure_at_surface"
+                   long_name="reference pressure at surface">
+      <type kind="kind_phys" units="mb">real</type>
+    </standard_name>
+    <standard_name name="reference_pressure_normalized_by_surface_pressure"
+                   long_name="reference pressure normalized by surface pressure">
       <type kind="kind_phys" units="mb">real</type>
     </standard_name>
     <standard_name name="exner_function"
@@ -253,6 +318,10 @@
     </standard_name>
     <standard_name name="potential_temperature"
                    long_name="potential temperature">
+      <type kind="kind_phys" units="K">real</type>
+    </standard_name>
+    <standard_name name="potential_temperature_on_previous_timestep"
+                   long_name="potential temperature on previous timestep">
       <type kind="kind_phys" units="K">real</type>
     </standard_name>
     <standard_name name="pressure_dependent_gas_constant_of_dry_air">
@@ -270,13 +339,28 @@
     </standard_name>
   </section>
   <section name="constituents">
+    <standard_name name="number_of_chemical_species">
+      <type kind="kind_phys" units="count">integer</type>
+    </standard_name>
+    <standard_name name="number_of_tracers">
+      <type kind="kind_phys" units="count">integer</type>
+    </standard_name>
     <standard_name name="water_vapor_specific_humidity">
       <type kind="kind_phys" units="kg kg-1">real</type>
     </standard_name>
     <standard_name name="water_vapor_mole_fraction">
       <type kind="kind_phys" units="mole mole-1">real</type>
     </standard_name>
+    <standard_name name="cloud_liquid_water_mixing_ratio_of_moist_air">
+                   long_name="Ratio of the mass of liquid water to the mass of moist air">
+      <type kind="kind_phys" units="kg kg-1">real</type>
+    </standard_name>
     <standard_name name="cloud_liquid_water_mixing_ratio">
+                   long_name="Ratio of the mass of liquid water to the mass of dry air">
+      <type kind="kind_phys" units="kg kg-1">real</type>
+    </standard_name>
+    <standard_name name="cloud_ice_mixing_ratio"
+                   long_name="Ratio of the mass of ice to the mass of dry air">
       <type kind="kind_phys" units="kg kg-1">real</type>
     </standard_name>
     <standard_name name="rain_water_mixing_ratio">

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -163,15 +163,12 @@
     <standard_name name="air_temperature_on_previous_timestep">
       <type kind="kind_phys" units="K">real</type>
     </standard_name>
-    <standard_name name="equivalent_potential_temperature">
-      <type kind="kind_phys" units="K">real</type>
-    </standard_name>
     <standard_name name="x_wind"
-                   long_name="Zonal wind">
+                   long_name="Horizontal wind in a direction perdendicular to y_wind">
       <type kind="kind_phys" units="m s-1">real</type>
     </standard_name>
     <standard_name name="y_wind"
-                   long_name="Meridional wind">
+                   long_name="Horizontal wind in a direction perdendicular to x_wind">
       <type kind="kind_phys" units="m s-1">real</type>
     </standard_name>
     <standard_name name="dry_static_energy"
@@ -276,14 +273,14 @@
       <type kind="kind_phys" units="K s-1">real</type>
     </standard_name>
     <standard_name name="tendency_of_x_wind"
-                   long_name="Change in zonal wind from a parameterization">
+                   long_name="Change in x wind from a parameterization">
       <type kind="kind_phys" units="m s-2">real</type>
     </standard_name>
     <standard_name name="total_tendency_of_x_wind">
       <type kind="kind_phys" units="m s-2">real</type>
     </standard_name>
     <standard_name name="tendency_of_y_wind"
-                   long_name="Change in meridional from a parameterization">
+                   long_name="Change in y wind from a parameterization">
       <type kind="kind_phys" units="m s-2">real</type>
     </standard_name>
     <standard_name name="total_tendency_of_y_wind">

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -313,7 +313,7 @@
     </standard_name>
     <standard_name name="exner_function"
                    long_name="exner function">
-      <type kind="kind_phys" units="none">real</type>
+      <type kind="kind_phys" units="1">real</type>
     </standard_name>
     <standard_name name="potential_temperature"
                    long_name="potential temperature">

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -161,7 +161,6 @@
     <standard_name name="air_temperature_on_previous_timestep">
       <type kind="kind_phys" units="K">real</type>
     </standard_name>
-    </standard_name>
     <standard_name name="equivalent_potential_temperature">
       <type kind="kind_phys" units="K">real</type>
     </standard_name>

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -80,7 +80,7 @@
     <standard_name name="base_state_surface_pressure_for_hybrid_vertical_coordinate">
       <type kind="kind_phys" units="molecules kmole-1">real</type>
     </standard_name>
-    <standard_name name="boltzman_constant">
+    <standard_name name="boltzmann_constant">
       <type kind="kind_phys" units="J K-1">real</type>
     </standard_name>
     <standard_name name="gas_constant_of_dry_air">

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -123,7 +123,7 @@
       <type kind="kind_phys" units="m s-2">real</type>
     </standard_name>
     <standard_name name="cell_area">
-      <type kind="kind_phys" units="radian+2">real</type>
+      <type kind="kind_phys" units="steradian">real</type>
     </standard_name>
     <standard_name name="cell_weight">
       <type kind="kind_phys" units="none">real</type>
@@ -205,7 +205,7 @@
       <type kind="kind_phys" units="Pa-1">real</type>
     </standard_name>
     <standard_name name="ln_of_air_pressure">
-      <type kind="kind_phys" units="ln(Pa)">real</type>
+      <type kind="kind_phys" units="1">real</type>
     </standard_name>
     <standard_name name="log_of_air_pressure_of_dry_air">
       <type kind="kind_phys" units="Pa">real</type>
@@ -227,10 +227,10 @@
       <type kind="kind_phys" units="Pa">real</type>
     </standard_name>
     <standard_name name="ln_of_air_pressure_at_interface">
-      <type kind="kind_phys" units="ln(Pa)">real</type>
+      <type kind="kind_phys" units="1">real</type>
     </standard_name>
     <standard_name name="ln_of_air_pressure_of_dry_air_at_interface">
-      <type kind="kind_phys" units="ln(Pa)">real</type>
+      <type kind="kind_phys" units="1">real</type>
     </standard_name>
     <standard_name name="largest_model_top_pressure_that_allows_molecular_diffusion">
       <type kind="kind_phys" units="Pa">real</type>

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -99,7 +99,7 @@
                    long_name="latent heat of vaporization of water at 0C">
       <type kind="kind_phys" units="J kg-1">real</type>
     </standard_name>
-    <standard_name name="density_of dry_air_at_stp">
+    <standard_name name="density_of_dry_air_at_stp">
       <type kind="kind_phys" units="kg m-3"></type>
     </standard_name>
     <standard_name name="density_of_liquid_water_at_0c"

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -75,10 +75,10 @@
   </section>
   <section name="constants">
     <standard_name name="avogadro_number">
-      <type kind="kind_phys" units="molecules kmole-1">real</type>
+      <type kind="kind_phys" units="molecules mole-1">real</type>
     </standard_name>
     <standard_name name="base_state_surface_pressure_for_hybrid_vertical_coordinate">
-      <type kind="kind_phys" units="molecules kmole-1">real</type>
+      <type kind="kind_phys" units="Pa">real</type>
     </standard_name>
     <standard_name name="boltzmann_constant">
       <type kind="kind_phys" units="J K-1">real</type>
@@ -92,15 +92,15 @@
     <standard_name name="specific_heat_of_dry_air_at_constant_pressure">
       <type kind="kind_phys" units="J kg-1 K-1">real</type>
     </standard_name>
-    <standard_name name="specific_heat_of_water_at_20c">
-      <type kind="kind_phys" units="??????????">real</type>
+    <standard_name name="specific_heat_of_liquid_water_at_20c">
+      <type kind="kind_phys" units="J kg-1 K-1">real</type>
     </standard_name>
     <standard_name name="latent_heat_of_vaporization_of_water_at_0c"
                    long_name="latent heat of vaporization of water at 0C">
       <type kind="kind_phys" units="J kg-1">real</type>
     </standard_name>
     <standard_name name="density_of_dry_air_at_stp">
-      <type kind="kind_phys" units="kg m-3"></type>
+      <type kind="kind_phys" units="kg m-3">real</type>
     </standard_name>
     <standard_name name="density_of_liquid_water_at_0c"
                    long_name="density of liquid water at 0C">
@@ -135,7 +135,7 @@
       <type kind="kind_phys" units="none">physics_state</type>
     </standard_name>
     <standard_name name="timestep_for_physics">
-      <type kind="kind_phys" units="none">integer</type>
+      <type kind="kind_phys" units="s">integer</type>
     </standard_name>
     <standard_name name="total_tendency_of_physics">
       <type kind="kind_phys" units="none">physics_tend</type>
@@ -174,7 +174,7 @@
     </standard_name>
     <standard_name name="dry_static_energy"
                    long_name="Dry static energy Content of Atmosphere Layer">
-      <type kind="kind_phys" units="J m-2">real</type>
+      <type kind="kind_phys" units="J kg-1">real</type>
     </standard_name>
     <standard_name name="lagrangian_vertical_coordinate"
                    long_name="flag indicating if vertical coordinate is lagrangian">
@@ -205,7 +205,7 @@
       <type kind="kind_phys" units="Pa-1">real</type>
     </standard_name>
     <standard_name name="ln_of_air_pressure">
-      <type kind="kind_phys" units="pmid">real</type>
+      <type kind="kind_phys" units="ln(Pa)">real</type>
     </standard_name>
     <standard_name name="log_of_air_pressure_of_dry_air">
       <type kind="kind_phys" units="Pa">real</type>
@@ -251,10 +251,10 @@
       <type kind="kind_phys" units="J m-2">real</type>
     </standard_name>
     <standard_name name="column_integrated_total_water_of_initial_state">
-      <type kind="kind_phys" units="Pa s2 m-1">real</type>
+      <type kind="kind_phys" units="kg m-2">real</type>
     </standard_name>
     <standard_name name="column_integrated_total_water_of_new_state">
-      <type kind="kind_phys" units="Pa s2 m-1">real</type>
+      <type kind="kind_phys" units="kg m-2">real</type>
     </standard_name>
     <standard_name name="tendency_of_temperature"
                    long_name="Change in temperature from a parameterization">
@@ -297,19 +297,19 @@
     </standard_name>
     <standard_name name="reference_pressure"
                    long_name="reference pressure ">
-      <type kind="kind_phys" units="mb">real</type>
+      <type kind="kind_phys" units="Pa">real</type>
     </standard_name>
     <standard_name name="us_standard_atmospheric_pressure_at_sea_level"
                    long_name="US Standard Atmospheric pressure at sea level">
-      <type kind="kind_phys" units="mb">real</type>
+      <type kind="kind_phys" units="Pa">real</type>
     </standard_name>
     <standard_name name="reference_pressure_at_surface"
                    long_name="reference pressure at surface">
-      <type kind="kind_phys" units="mb">real</type>
+      <type kind="kind_phys" units="Pa">real</type>
     </standard_name>
     <standard_name name="reference_pressure_normalized_by_surface_pressure"
                    long_name="reference pressure normalized by surface pressure">
-      <type kind="kind_phys" units="mb">real</type>
+      <type kind="kind_phys" units="none">real</type>
     </standard_name>
     <standard_name name="exner_function"
                    long_name="exner function">

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -92,14 +92,16 @@
     <standard_name name="specific_heat_of_dry_air_at_constant_pressure">
       <type kind="kind_phys" units="J kg-1 K-1">real</type>
     </standard_name>
-    <standard_name name="specific_heat_of_liquid_water_at_20c">
+    <standard_name name="specific_heat_of_liquid_water_at_20c" 
+              long_name="specific heat of liquid water at 20C">
       <type kind="kind_phys" units="J kg-1 K-1">real</type>
     </standard_name>
     <standard_name name="latent_heat_of_vaporization_of_water_at_0c"
                    long_name="latent heat of vaporization of water at 0C">
       <type kind="kind_phys" units="J kg-1">real</type>
     </standard_name>
-    <standard_name name="density_of_dry_air_at_stp">
+    <standard_name name="density_of_dry_air_at_stp" 
+              long_name="density of dry air at STP">
       <type kind="kind_phys" units="kg m-3">real</type>
     </standard_name>
     <standard_name name="density_of_liquid_water_at_0c"
@@ -130,7 +132,7 @@
     </standard_name>
   </section>
   <section name="state_variables"
-           comment="Note that appending '_from_previous_timestep' to standard_names in this section yields another valid standard_name">
+           comment="Note that appending '_on_previous_timestep' to standard_names in this section yields another valid standard_name">
     <standard_name name="physics_state_due_to_dynamics">
       <type kind="kind_phys" units="none">physics_state</type>
     </standard_name>
@@ -238,7 +240,8 @@
     <standard_name name="flag_for_molecular_diffusion">
       <type kind="kind_phys" units="flag">logical</type>
     </standard_name>
-    <standard_name name="flag_for_physics_grid_initialization">
+    <standard_name name="flag_for_physics_grid_initialization" 
+              long_name="Flag to indicate if physics grid is initialized">
       <type kind="kind_phys" units="flag">logical</type>
     </standard_name>
     <standard_name name="geopotential_height_at_interface">
@@ -253,7 +256,7 @@
     <standard_name name="column_integrated_total_water_of_initial_state">
       <type kind="kind_phys" units="kg m-2">real</type>
     </standard_name>
-    <standard_name name="column_integrated_total_water_of_new_state">
+    <standard_name name="column_integrated_total_water_of_current_state">
       <type kind="kind_phys" units="kg m-2">real</type>
     </standard_name>
     <standard_name name="tendency_of_temperature"
@@ -309,7 +312,7 @@
     </standard_name>
     <standard_name name="reference_pressure_normalized_by_surface_pressure"
                    long_name="reference pressure normalized by surface pressure">
-      <type kind="kind_phys" units="none">real</type>
+      <type kind="kind_phys" units="1">real</type>
     </standard_name>
     <standard_name name="exner_function"
                    long_name="exner function">

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -347,7 +347,7 @@
     <standard_name name="water_vapor_specific_humidity">
       <type kind="kind_phys" units="kg kg-1">real</type>
     </standard_name>
-    <standard_name name="water_vapor_mole_fraction">
+    <standard_name name="mole_fraction_of_water_vapor">
       <type kind="kind_phys" units="mole mole-1">real</type>
     </standard_name>
     <standard_name name="cloud_liquid_water_mixing_ratio_of_moist_air">

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -209,7 +209,7 @@
     <standard_name name="log_of_air_pressure_of_dry_air">
       <type kind="kind_phys" units="Pa">real</type>
     </standard_name>
-    <standard_name name="inverse_dimensionless_exner_function_wrt_surface_pressure"
+    <standard_name name="inverse_exner_function_wrt_surface_pressure"
                    long_name="inverse exner function w.r.t. surface pressure, (ps/p)^(R/cp)">
       <type kind="kind_phys" units="1">real</type>
     </standard_name>


### PR DESCRIPTION
Synchronize standard_names used in CAMDEN with input from list from WRF and NOAA SCM model.  Also get input from the CF conventions and attempt to adhere to NOAA's CCPP naming guidelines.

closes #8