### PR TITLE
Correct spelling of "janic" to "janjic"

### DIFF
--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -372,9 +372,9 @@ Standard / required CCPP variables
     * `real(kind=kind_phys)`: units = 1
 * `directory_for_rte_rrtmgp_source_code`: Directory for rte rrtmgp source code
     * `character(kind=len=128)`: units = none
-* `do_mellor_yamada_janic_pbl_scheme`: Do mellor yamada janic pbl scheme
+* `do_mellor_yamada_janjic_pbl_scheme`: Do mellor yamada janjic pbl scheme
     * `logical(kind=)`: units = flag
-* `do_mellor_yamada_janic_surface_layer_scheme`: Do mellor yamada janic surface layer scheme
+* `do_mellor_yamada_janjic_surface_layer_scheme`: Do mellor yamada janjic surface layer scheme
     * `logical(kind=)`: units = flag
 * `do_mellor_yamada_nakanishi_niino_pbl_scheme`: Do mellor yamada nakanishi niino pbl scheme
     * `logical(kind=)`: units = flag
@@ -1238,7 +1238,7 @@ Standard / required CCPP variables
     * `real(kind=kind_phys)`: units = kg-1
 * `upward_virtual_potential_temperature_flux`: Upward virtual potential temperature flux
     * `real(kind=kind_phys)`: units = K m s-1
-* `surface_upward_specific_humidity_flux_for_mellor_yamada_janic_surface_layer_scheme`: Surface upward specific humidity flux for mellor yamada janic surface layer scheme
+* `surface_upward_specific_humidity_flux_for_mellor_yamada_janjic_surface_layer_scheme`: Surface upward specific humidity flux for mellor yamada janjic surface layer scheme
     * `real(kind=kind_phys)`: units = m s-1 kg kg-1
 * `cumulative_max_vertical_index_at_cloud_base_between_sw_radiation_calls`: Cumulative max vertical index at cloud base between sw radiation calls
     * `real(kind=kind_phys)`: units = 1

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -590,10 +590,10 @@
       <standard_name name="directory_for_rte_rrtmgp_source_code">
          <type kind="len=128" units="none">character</type>
       </standard_name>
-      <standard_name name="do_mellor_yamada_janic_pbl_scheme">
+      <standard_name name="do_mellor_yamada_janjic_pbl_scheme">
          <type kind="" units="flag">logical</type>
       </standard_name>
-      <standard_name name="do_mellor_yamada_janic_surface_layer_scheme">
+      <standard_name name="do_mellor_yamada_janjic_surface_layer_scheme">
          <type kind="" units="flag">logical</type>
       </standard_name>
       <standard_name name="do_mellor_yamada_nakanishi_niino_pbl_scheme">
@@ -1890,7 +1890,7 @@
       <standard_name name="upward_virtual_potential_temperature_flux">
          <type kind="kind_phys" units="K m s-1">real</type>
       </standard_name>
-      <standard_name name="surface_upward_specific_humidity_flux_for_mellor_yamada_janic_surface_layer_scheme">
+      <standard_name name="surface_upward_specific_humidity_flux_for_mellor_yamada_janjic_surface_layer_scheme">
          <type kind="kind_phys" units="m s-1 kg kg-1">real</type>
       </standard_name>
       <standard_name name="cumulative_max_vertical_index_at_cloud_base_between_sw_radiation_calls">


### PR DESCRIPTION
Three standard names are wrong in the dictionary, "janic" needs to be "janjic" (thanks @dusanjovic-noaa for spotting this). 

The corresponding ccpp-physics, fv3atm and ccpp-scm PRs are:

https://github.com/NCAR/ccpp-physics/pull/766
https://github.com/NOAA-EMC/fv3atm/pull/416
https://github.com/NCAR/ccpp-scm/pull/279

For regression testing with the UFS, see https://github.com/ufs-community/ufs-weather-model/pull/892.