### PR TITLE
Add JEDI UFO CF-compliant names

### DIFF
--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -149,6 +149,8 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = 1
 * `geopotential_height`: Geopotential height
     * `real(kind=kind_phys)`: units = m
+* `height`: Vertical distance above the surface
+    * `real(kind=kind_phys)`: units = m
 * `potentially_advected_quantities`: Potentially advected quantities
     * `real(kind=kind_phys)`: units = various
 * `air_pressure_at_interface`: Air pressure at interface

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -243,6 +243,8 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = mol mol-1
 * `mole_fraction_of_carbon_dioxide_in_air`: Mole fraction of carbon dioxide in air
     * `real(kind=kind_phys)`: units = mol mol-1
+* `humidity_mixing_ratio`: Water vapor mixing ratio wrt dry air
+    * `real(kind=kind_phys)`: units = kg kg-1
 * `cloud_liquid_water_mixing_ratio_wrt_moist_air`: Cloud liquid water mixing ratio wrt moist air
     * `real(kind=kind_phys)`: units = kg kg-1
 * `cloud_liquid_water_mixing_ratio_wrt_dry_air`: Cloud liquid water mixing ratio wrt dry air

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -221,6 +221,8 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = kg m-2
 * `mass_content_of_cloud_liquid_water_in_atmosphere_layer`: mass content of cloud liquid water in atmosphere layer
     * `real(kind=kind_phys)`: units = kg m-2
+* `cloud_area_fraction_in_atmosphere_layer`: cloud area fraction in atmosphere layer
+    * `real(kind=kind_phys)`: units = 1
 ## diagnostics
 * `total_precipitation_rate_at_surface`: Total precipitation rate at surface
     * `real(kind=kind_phys)`: units = m s-1

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -149,8 +149,6 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = 1
 * `geopotential_height`: Geopotential height
     * `real(kind=kind_phys)`: units = m
-* `height`: Vertical distance above the surface
-    * `real(kind=kind_phys)`: units = m
 * `potentially_advected_quantities`: Potentially advected quantities
     * `real(kind=kind_phys)`: units = various
 * `air_pressure_at_interface`: Air pressure at interface
@@ -219,13 +217,13 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = J kg-1 K-1
 * `pressure_dependent_ratio_of_dry_air_to_water_vapor_gas_constants_minus_one`: (Rwv / Rdair) - 1.0
     * `real(kind=kind_phys)`: units = 1
-* `mass_content_of_cloud_ice_in_atmosphere_layer`: mass content of cloud ice in atmosphere layer
+* `mass_content_of_cloud_ice_in_atmosphere_layer`: Mass content of cloud ice in atmosphere layer
     * `real(kind=kind_phys)`: units = kg m-2
-* `mass_content_of_cloud_liquid_water_in_atmosphere_layer`: mass content of cloud liquid water in atmosphere layer
+* `mass_content_of_cloud_liquid_water_in_atmosphere_layer`: Mass content of cloud liquid water in atmosphere layer
     * `real(kind=kind_phys)`: units = kg m-2
-* `cloud_area_fraction_in_atmosphere_layer`: cloud area fraction in atmosphere layer
+* `cloud_area_fraction_in_atmosphere_layer`: Cloud area fraction in atmosphere layer
     * `real(kind=kind_phys)`: units = 1
-* `relative_humidity`: relative humidity
+* `relative_humidity`: Relative humidity
     * `real(kind=kind_phys)`: units = 1
 ## diagnostics
 * `total_precipitation_rate_at_surface`: Total precipitation rate at surface
@@ -243,11 +241,11 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = mol mol-1
 * `mole_fraction_of_carbon_dioxide_in_air`: Mole fraction of carbon dioxide in air
     * `real(kind=kind_phys)`: units = mol mol-1
-* `humidity_mixing_ratio`: Water vapor mixing ratio wrt dry air
+* `water_vapor_mixing_ratio_wrt_dry_air`: Ratio of the mass of water vapor to the mass of dry air
     * `real(kind=kind_phys)`: units = kg kg-1
-* `cloud_liquid_water_mixing_ratio_wrt_moist_air`: Cloud liquid water mixing ratio wrt moist air
+* `cloud_liquid_water_mixing_ratio_wrt_moist_air`: Ratio of the mass of liquid water to the mass of moist air
     * `real(kind=kind_phys)`: units = kg kg-1
-* `cloud_liquid_water_mixing_ratio_wrt_dry_air`: Cloud liquid water mixing ratio wrt dry air
+* `cloud_liquid_water_mixing_ratio_wrt_dry_air`: Ratio of the mass of liquid water to the mass of dry air
     * `real(kind=kind_phys)`: units = kg kg-1
 * `cloud_ice_mixing_ratio_wrt_dry_air`: Ratio of the mass of ice to the mass of dry air
     * `real(kind=kind_phys)`: units = kg kg-1

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -119,6 +119,10 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = m s-1
 * `y_wind`: Horizontal wind in a direction perdendicular to x_wind
     * `real(kind=kind_phys)`: units = m s-1
+* `eastward_wind`: Wind vector component, positive when directed eastward
+    * `real(kind=kind_phys)`: units = m s-1
+* `northward_wind`: Wind vector component, positive when directed northward
+    * `real(kind=kind_phys)`: units = m s-1
 * `dry_static_energy`: Dry static energy Content of Atmosphere Layer
     * `real(kind=kind_phys)`: units = J kg-1
 * `do_lagrangian_vertical_coordinate`: flag indicating if vertical coordinate is lagrangian

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -231,6 +231,8 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = mol mol-1
 * `mole_fraction_of_ozone_in_air`: Mole fraction of ozone in air
     * `real(kind=kind_phys)`: units = mol mol-1
+* `mole_fraction_of_carbon_dioxide_in_air`: Mole fraction of carbon dioxide in air
+    * `real(kind=kind_phys)`: units = mol mol-1
 * `cloud_liquid_water_mixing_ratio_wrt_moist_air`: Cloud liquid water mixing ratio wrt moist air
     * `real(kind=kind_phys)`: units = kg kg-1
 * `cloud_liquid_water_mixing_ratio_wrt_dry_air`: Cloud liquid water mixing ratio wrt dry air

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -229,6 +229,8 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = kg kg-1
 * `mole_fraction_of_water_vapor`: Mole fraction of water vapor
     * `real(kind=kind_phys)`: units = mol mol-1
+* `mole_fraction_of_ozone_in_air`: Mole fraction of ozone in air
+    * `real(kind=kind_phys)`: units = mol mol-1
 * `cloud_liquid_water_mixing_ratio_wrt_moist_air`: Cloud liquid water mixing ratio wrt moist air
     * `real(kind=kind_phys)`: units = kg kg-1
 * `cloud_liquid_water_mixing_ratio_wrt_dry_air`: Cloud liquid water mixing ratio wrt dry air

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -223,6 +223,8 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = kg m-2
 * `cloud_area_fraction_in_atmosphere_layer`: cloud area fraction in atmosphere layer
     * `real(kind=kind_phys)`: units = 1
+* `relative_humidity`: relative humidity
+    * `real(kind=kind_phys)`: units = 1
 ## diagnostics
 * `total_precipitation_rate_at_surface`: Total precipitation rate at surface
     * `real(kind=kind_phys)`: units = m s-1

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -217,6 +217,10 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = J kg-1 K-1
 * `pressure_dependent_ratio_of_dry_air_to_water_vapor_gas_constants_minus_one`: (Rwv / Rdair) - 1.0
     * `real(kind=kind_phys)`: units = 1
+* `mass_content_of_cloud_ice_in_atmosphere_layer`: mass content of cloud ice in atmosphere layer
+    * `real(kind=kind_phys)`: units = kg m-2
+* `mass_content_of_cloud_liquid_water_in_atmosphere_layer`: mass content of cloud liquid water in atmosphere layer
+    * `real(kind=kind_phys)`: units = kg m-2
 ## diagnostics
 * `total_precipitation_rate_at_surface`: Total precipitation rate at surface
     * `real(kind=kind_phys)`: units = m s-1

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -207,6 +207,8 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = K
 * `air_potential_temperature_on_previous_timestep`: air potential temperature on previous timestep
     * `real(kind=kind_phys)`: units = K
+* `virtual_temperature`: virtual temperature
+    * `real(kind=kind_phys)`: units = K
 * `pressure_dependent_gas_constant_of_dry_air`: Pressure dependent gas constant of dry air
     * `real(kind=kind_phys)`: units = J kg-1 K-1
 * `pressure_dependent_ratio_of_dry_air_to_water_vapor_gas_constants_minus_one`: (Rwv / Rdair) - 1.0

--- a/StandardNamesRules.rst
+++ b/StandardNamesRules.rst
@@ -68,6 +68,10 @@ CCPP Standard Name Rules
 
 #. Volume mixing ratios should be qualified as *volume_mixing_ratio*.
 
+#. By default, *mole_fraction_of_X_in_Y* refers to the total amount of *Y*. So, for example,
+   *mole_fraction_of_ozone_in_air* refers to the total amount of air. When this is not the case,
+   a qualifier should be used to denote this. *e.g.*, *mole_fraction_of_ozone_in_dry_air*.
+
 #. When referring to soil quantities, 
    *volume_fraction* should be used to express the volumetric soil moisture.
 

--- a/StandardNamesRules.rst
+++ b/StandardNamesRules.rst
@@ -69,8 +69,9 @@ CCPP Standard Name Rules
 #. Volume mixing ratios should be qualified as *volume_mixing_ratio*.
 
 #. By default, *mole_fraction_of_X_in_Y* refers to the total amount of *Y*. So, for example,
-   *mole_fraction_of_ozone_in_air* refers to the total amount of air. When this is not the case,
-   a qualifier should be used to denote this. *e.g.*, *mole_fraction_of_ozone_in_dry_air*.
+   *mole_fraction_of_ozone_in_air* refers to the total amount of (moist) air. (In the case of air,
+   the default meaning is moist air, as described in the *mixing ratio* rule.) When this is not
+   the case, a qualifier should be used to denote this. *e.g.*, *mole_fraction_of_ozone_in_dry_air*. 
 
 #. When referring to soil quantities, 
    *volume_fraction* should be used to express the volumetric soil moisture.

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -365,6 +365,9 @@
     <standard_name name="mole_fraction_of_ozone_in_air">
       <type kind="kind_phys" units="mol mol-1">real</type>
     </standard_name>
+    <standard_name name="mole_fraction_of_carbon_dioxide_in_air">
+      <type kind="kind_phys" units="mol mol-1">real</type>
+    </standard_name>
     <standard_name name="cloud_liquid_water_mixing_ratio_wrt_moist_air">
                    long_name="Ratio of the mass of liquid water to the mass of moist air">
       <type kind="kind_phys" units="kg kg-1">real</type>

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -171,6 +171,14 @@
                    long_name="Horizontal wind in a direction perdendicular to x_wind">
       <type kind="kind_phys" units="m s-1">real</type>
     </standard_name>
+    <standard_name name="eastward_wind"
+                   long_name="Wind vector component, positive when directed eastward">
+      <type kind="kind_phys" units="m s-1">real</type>
+    </standard_name>
+    <standard_name name="northward_wind"
+                   long_name="Wind vector component, positive when directed northward">
+      <type kind="kind_phys" units="m s-1">real</type>
+    </standard_name>
     <standard_name name="dry_static_energy"
                    long_name="Dry static energy Content of Atmosphere Layer">
       <type kind="kind_phys" units="J kg-1">real</type>

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -362,6 +362,9 @@
     <standard_name name="mole_fraction_of_water_vapor">
       <type kind="kind_phys" units="mol mol-1">real</type>
     </standard_name>
+    <standard_name name="mole_fraction_of_ozone_in_air">
+      <type kind="kind_phys" units="mol mol-1">real</type>
+    </standard_name>
     <standard_name name="cloud_liquid_water_mixing_ratio_wrt_moist_air">
                    long_name="Ratio of the mass of liquid water to the mass of moist air">
       <type kind="kind_phys" units="kg kg-1">real</type>

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -323,6 +323,10 @@
                    long_name="air potential temperature on previous timestep">
       <type kind="kind_phys" units="K">real</type>
     </standard_name>
+    <standard_name name="virtual_temperature"
+                   long_name="virtual temperature">
+      <type kind="kind_phys" units="K">real</type>
+    </standard_name>
     <standard_name name="pressure_dependent_gas_constant_of_dry_air">
       <type kind="kind_phys" units="J kg-1 K-1">real</type>
     </standard_name>

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -352,6 +352,9 @@
     <standard_name name="cloud_area_fraction_in_atmosphere_layer">
       <type kind="kind_phys" units="1">real</type>
     </standard_name>
+    <standard_name name="relative_humidity">
+      <type kind="kind_phys" units="1">real</type>
+    </standard_name>
   </section>
   <section name="diagnostics">
     <standard_name name="total_precipitation_rate_at_surface">

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -383,6 +383,10 @@
     <standard_name name="mole_fraction_of_carbon_dioxide_in_air">
       <type kind="kind_phys" units="mol mol-1">real</type>
     </standard_name>
+    <standard_name name="humidity_mixing_ratio">
+                   long_name="Ratio of the mass of water vapor to the mass of dry air">
+      <type kind="kind_phys" units="kg kg-1">real</type>
+    </standard_name>
     <standard_name name="cloud_liquid_water_mixing_ratio_wrt_moist_air">
                    long_name="Ratio of the mass of liquid water to the mass of moist air">
       <type kind="kind_phys" units="kg kg-1">real</type>

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -383,7 +383,7 @@
     <standard_name name="mole_fraction_of_carbon_dioxide_in_air">
       <type kind="kind_phys" units="mol mol-1">real</type>
     </standard_name>
-    <standard_name name="humidity_mixing_ratio">
+    <standard_name name="water_vapor_mixing_ratio_wrt_dry_air">
                    long_name="Ratio of the mass of water vapor to the mass of dry air">
       <type kind="kind_phys" units="kg kg-1">real</type>
     </standard_name>

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -349,6 +349,9 @@
     <standard_name name="mass_content_of_cloud_liquid_water_in_atmosphere_layer">
       <type kind="kind_phys" units="kg m-2">real</type>
     </standard_name>
+    <standard_name name="cloud_area_fraction_in_atmosphere_layer">
+      <type kind="kind_phys" units="1">real</type>
+    </standard_name>
   </section>
   <section name="diagnostics">
     <standard_name name="total_precipitation_rate_at_surface">

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -224,9 +224,6 @@
     <standard_name name="geopotential_height">
       <type kind="kind_phys" units="m">real</type>
     </standard_name>
-    <standard_name name="height">
-      <type kind="kind_phys" units="m">real</type>
-    </standard_name>
     <standard_name name="potentially_advected_quantities">
       <type kind="kind_phys" units="various">real</type>
     </standard_name>
@@ -383,15 +380,15 @@
     <standard_name name="mole_fraction_of_carbon_dioxide_in_air">
       <type kind="kind_phys" units="mol mol-1">real</type>
     </standard_name>
-    <standard_name name="water_vapor_mixing_ratio_wrt_dry_air">
+    <standard_name name="water_vapor_mixing_ratio_wrt_dry_air"
                    long_name="Ratio of the mass of water vapor to the mass of dry air">
       <type kind="kind_phys" units="kg kg-1">real</type>
     </standard_name>
-    <standard_name name="cloud_liquid_water_mixing_ratio_wrt_moist_air">
+    <standard_name name="cloud_liquid_water_mixing_ratio_wrt_moist_air"
                    long_name="Ratio of the mass of liquid water to the mass of moist air">
       <type kind="kind_phys" units="kg kg-1">real</type>
     </standard_name>
-    <standard_name name="cloud_liquid_water_mixing_ratio_wrt_dry_air">
+    <standard_name name="cloud_liquid_water_mixing_ratio_wrt_dry_air"
                    long_name="Ratio of the mass of liquid water to the mass of dry air">
       <type kind="kind_phys" units="kg kg-1">real</type>
     </standard_name>

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -224,6 +224,9 @@
     <standard_name name="geopotential_height">
       <type kind="kind_phys" units="m">real</type>
     </standard_name>
+    <standard_name name="height">
+      <type kind="kind_phys" units="m">real</type>
+    </standard_name>
     <standard_name name="potentially_advected_quantities">
       <type kind="kind_phys" units="various">real</type>
     </standard_name>

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -343,6 +343,12 @@
         long_name="(Rwv / Rdair) - 1.0">
       <type kind="kind_phys" units="1">real</type>
     </standard_name>
+    <standard_name name="mass_content_of_cloud_ice_in_atmosphere_layer">
+      <type kind="kind_phys" units="kg m-2">real</type>
+    </standard_name>
+    <standard_name name="mass_content_of_cloud_liquid_water_in_atmosphere_layer">
+      <type kind="kind_phys" units="kg m-2">real</type>
+    </standard_name>
   </section>
   <section name="diagnostics">
     <standard_name name="total_precipitation_rate_at_surface">


### PR DESCRIPTION
The [JCSDA JEDI software project](https://www.jcsda.org/jcsda-project-jedi) has decided to adopt the CCPP naming standard to use for model variables in its generic code. This PR adds some variable names to CCPP that are already CF-standards and are in use in JEDI.

This is my first attempt at a PR for this repository, so apologies if I haven't done it quite right. I'm happy to modify.