### PR TITLE
Updates to geopotential height and reference pressure

### DIFF
--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -204,7 +204,7 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
 * `reference_pressure`: A constant reference pressure value of 1000 hPa
     * `real(kind=kind_phys)`: units = Pa
 * `reference_pressure_of_atmosphere_layer`: The reference pressure for a given atmosphere layer
-    * `real(kind=kind_phys)`: units = None
+    * `real(kind=kind_phys)`: units = Pa
 * `reference_air_pressure_normalized_by_surface_air_pressure`: reference pressure normalized by surface pressure
     * `real(kind=kind_phys)`: units = 1
 * `dimensionless_exner_function`: exner function

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -201,7 +201,7 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = W m-2
 * `US_standard_air_pressure_at_sea_level`: US Standard Atmospheric pressure at sea level
     * `real(kind=kind_phys)`: units = Pa
-* `reference_pressure`: A constant reference pressure value of 1000 hPa
+* `reference_pressure`: reference pressure used in definition of potential temperature, Exner function, etc.
     * `real(kind=kind_phys)`: units = Pa
 * `reference_pressure_in_atmosphere_layer`: reference pressure in atmosphere layer
     * `real(kind=kind_phys)`: units = Pa

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -203,7 +203,7 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = Pa
 * `reference_pressure`: A constant reference pressure value of 1000 hPa
     * `real(kind=kind_phys)`: units = Pa
-* `reference_pressure_of_atmosphere_layer`: The reference pressure for a given atmosphere layer
+* `reference_pressure_in_atmosphere_layer`: The reference pressure for a given atmosphere layer
     * `real(kind=kind_phys)`: units = Pa
 * `reference_air_pressure_normalized_by_surface_air_pressure`: reference pressure normalized by surface pressure
     * `real(kind=kind_phys)`: units = 1

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -203,7 +203,7 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = Pa
 * `reference_pressure`: A constant reference pressure value of 1000 hPa
     * `real(kind=kind_phys)`: units = Pa
-* `reference_pressure_in_atmosphere_layer`: The reference pressure for a given atmosphere layer
+* `reference_pressure_in_atmosphere_layer`: reference pressure in atmosphere layer
     * `real(kind=kind_phys)`: units = Pa
 * `reference_air_pressure_normalized_by_surface_air_pressure`: reference pressure normalized by surface pressure
     * `real(kind=kind_phys)`: units = 1

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -147,7 +147,9 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = 1
 * `reciprocal_of_dimensionless_exner_function_wrt_surface_air_pressure`: inverse exner function w.r.t. surface pressure, (ps/p)^(R/cp)
     * `real(kind=kind_phys)`: units = 1
-* `geopotential_height`: Geopotential height
+* `geopotential_height`: geopotential height w.r.t. sea level
+    * `real(kind=kind_phys)`: units = m
+* `geopotential_height_wrt_surface`: geopotential height w.r.t. local surface
     * `real(kind=kind_phys)`: units = m
 * `potentially_advected_quantities`: Potentially advected quantities
     * `real(kind=kind_phys)`: units = various
@@ -197,12 +199,12 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = W m-2
 * `cumulative_boundary_flux_of_total_water`: Cumulative boundary flux of total water
     * `real(kind=kind_phys)`: units = W m-2
-* `reference_pressure`: reference pressure 
-    * `real(kind=kind_phys)`: units = Pa
 * `US_standard_air_pressure_at_sea_level`: US Standard Atmospheric pressure at sea level
     * `real(kind=kind_phys)`: units = Pa
-* `reference_pressure_at_surface`: reference pressure at surface
+* `reference_pressure`: A constant reference pressure value of 1000 hPa
     * `real(kind=kind_phys)`: units = Pa
+* `reference_pressure_of_atmosphere_layer`: The reference pressure for a given atmosphere layer
+    * `real(kind=kind_phys)`: units = None
 * `reference_air_pressure_normalized_by_surface_air_pressure`: reference pressure normalized by surface pressure
     * `real(kind=kind_phys)`: units = 1
 * `dimensionless_exner_function`: exner function

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -316,7 +316,7 @@
                    long_name="A constant reference pressure value of 1000 hPa">
       <type kind="kind_phys" units="Pa">real</type>
     </standard_name>
-    <standard_name name="reference_pressure_of_atmosphere_layer"
+    <standard_name name="reference_pressure_in_atmosphere_layer"
                    long_name="The reference pressure for a given atmosphere layer">
       <type kind="kind_phys" units="Pa">real</type>
     </standard_name>

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -221,7 +221,12 @@
                    long_name="inverse exner function w.r.t. surface pressure, (ps/p)^(R/cp)">
       <type kind="kind_phys" units="1">real</type>
     </standard_name>
-    <standard_name name="geopotential_height">
+    <standard_name name="geopotential_height"
+                   long_name="geopotential height w.r.t. sea level">
+      <type kind="kind_phys" units="m">real</type>
+    </standard_name>
+    <standard_name name="geopotential_height_wrt_surface"
+                   long_name="geopotential height w.r.t. local surface">
       <type kind="kind_phys" units="m">real</type>
     </standard_name>
     <standard_name name="potentially_advected_quantities">
@@ -303,17 +308,17 @@
     <standard_name name="cumulative_boundary_flux_of_total_water">
       <type kind="kind_phys" units="W m-2">real</type>
     </standard_name>
-    <standard_name name="reference_pressure"
-                   long_name="reference pressure ">
-      <type kind="kind_phys" units="Pa">real</type>
-    </standard_name>
     <standard_name name="US_standard_air_pressure_at_sea_level"
                    long_name="US Standard Atmospheric pressure at sea level">
       <type kind="kind_phys" units="Pa">real</type>
     </standard_name>
-    <standard_name name="reference_pressure_at_surface"
-                   long_name="reference pressure at surface">
+    <standard_name name="reference_pressure"
+                   long_name="A constant reference pressure value of 1000 hPa">
       <type kind="kind_phys" units="Pa">real</type>
+    </standard_name>
+    <standard_name name="reference_pressure_of_atmosphere_layer"
+                   long_name="The reference pressure for a given atmosphere layer">
+      <type kind="kind_phys" unites="Pa">real</type>
     </standard_name>
     <standard_name name="reference_air_pressure_normalized_by_surface_air_pressure"
                    long_name="reference pressure normalized by surface pressure">

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -318,7 +318,7 @@
     </standard_name>
     <standard_name name="reference_pressure_of_atmosphere_layer"
                    long_name="The reference pressure for a given atmosphere layer">
-      <type kind="kind_phys" unites="Pa">real</type>
+      <type kind="kind_phys" units="Pa">real</type>
     </standard_name>
     <standard_name name="reference_air_pressure_normalized_by_surface_air_pressure"
                    long_name="reference pressure normalized by surface pressure">

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -92,7 +92,7 @@
     <standard_name name="specific_heat_of_dry_air_at_constant_pressure">
       <type kind="kind_phys" units="J kg-1 K-1">real</type>
     </standard_name>
-    <standard_name name="specific_heat_of_liquid_water_at_20c" 
+    <standard_name name="specific_heat_of_liquid_water_at_20c"
               long_name="specific heat of liquid water at 20c">
       <type kind="kind_phys" units="J kg-1 K-1">real</type>
     </standard_name>
@@ -100,7 +100,7 @@
                    long_name="latent heat of vaporization of water at 0c">
       <type kind="kind_phys" units="J kg-1">real</type>
     </standard_name>
-    <standard_name name="dry_air_density_at_stp" 
+    <standard_name name="dry_air_density_at_stp"
               long_name="density of dry air at STP">
       <type kind="kind_phys" units="kg m-3">real</type>
     </standard_name>
@@ -250,7 +250,7 @@
     <standard_name name="do_molecular_diffusion">
       <type kind="kind_phys" units="flag">logical</type>
     </standard_name>
-    <standard_name name="is_initialized_physics_grid" 
+    <standard_name name="is_initialized_physics_grid"
               long_name="Flag to indicate if physics grid is initialized">
       <type kind="kind_phys" units="flag">logical</type>
     </standard_name>
@@ -317,7 +317,7 @@
       <type kind="kind_phys" units="Pa">real</type>
     </standard_name>
     <standard_name name="reference_pressure_in_atmosphere_layer"
-                   long_name="The reference pressure for a given atmosphere layer">
+                   long_name="reference pressure in atmosphere layer">
       <type kind="kind_phys" units="Pa">real</type>
     </standard_name>
     <standard_name name="reference_air_pressure_normalized_by_surface_air_pressure"

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -313,7 +313,7 @@
       <type kind="kind_phys" units="Pa">real</type>
     </standard_name>
     <standard_name name="reference_pressure"
-                   long_name="A constant reference pressure value of 1000 hPa">
+                   long_name="reference pressure used in definition of potential temperature, Exner function, etc.">
       <type kind="kind_phys" units="Pa">real</type>
     </standard_name>
     <standard_name name="reference_pressure_in_atmosphere_layer"


### PR DESCRIPTION
As discussed in the February 27th, 2023 framework meeting, scientists in NCAR CGD requested that some of the standard names related to geopotential height and reference pressure be modified to either be more explicit or to better match already existing standards.  This PR implements those requests.

Also, I wasn't sure who to request a review from, so I selected semi-randomly based off of previous PRs.  If I missed anyone, or selected someone who doesn't need to review, then please let me know.  Thanks!