### PR TITLE
Fix bugs in python table writing and checking scripts

### DIFF
--- a/check_xml_unique.py
+++ b/check_xml_unique.py
@@ -22,7 +22,7 @@ def parse_command_line(args, description):
                         type=str, help="XML file with standard name library")
     parser.add_argument("--overwrite", action='store_true',
                         help="flag to remove duplicates and overwrite the file")
-    
+
     pargs = parser.parse_args(args)
     return pargs
 
@@ -33,14 +33,14 @@ def main_func():
     """
     # Parse command line arguments
     args = parse_command_line(sys.argv[1:], __doc__)
-    stdname_file = os.path.abspath(args.standard_name_file)    
-    _, root = read_xml_file(stdname_file)
-        
+    stdname_file = os.path.abspath(args.standard_name_file)
+    tree, root = read_xml_file(stdname_file)
+
     #get list of all standard names
     all_std_names = []
     for name in root.findall('./section/standard_name'):
         all_std_names.append(name.attrib['name'])
-    
+
     #get list of all unique and duplicate standard names, in source order
     seen = set()
     uniq_std_names = []
@@ -51,7 +51,7 @@ def main_func():
             seen.add(x)
         else:
             dup_std_names.append(x)
-    
+
     if args.overwrite:
         #delete all duplicate elements after the first
         if len(dup_std_names)>0:
@@ -61,13 +61,18 @@ def main_func():
                 print("{0}, ({1} duplicate(s))".format(dup, len(rm_elements)))
             print('Removing duplicates and overwriting {}'.format(stdname_file))
             for dup in dup_std_names:
-                rm_parents = root.findall('./section/standard_name[@name="%s"]...'%dup)[1:]
+                first_name = True #Logical that indicates the first of the duplicated names
+                rm_parents = root.findall('./section/standard_name[@name="%s"]..'%dup)
                 for par in rm_parents:
                     rm_ele = par.findall('./standard_name[@name="%s"]'%dup)
                     for ele in rm_ele:
-                        par.remove(ele)
-            
-            _.write(stdname_file, "utf-8")
+                        if first_name:
+                            #Now all future names will be removed:
+                            first_name = False
+                        else:
+                            par.remove(ele)
+            #Overwrite the xml file with the new, duplicate-free element tree:
+            tree.write(stdname_file, "utf-8")
         else:
             print('No duplicate standard names were found.')
     else:
@@ -79,7 +84,7 @@ def main_func():
                 print("{0}, ({1} duplicate(s))".format(dup, len(rm_elements)))
         else:
             print('No duplicate standard names were found.')
-    
+
 ###############################################################################
 if __name__ == "__main__":
     main_func()

--- a/check_xml_unique.py
+++ b/check_xml_unique.py
@@ -61,14 +61,14 @@ def main_func():
                 print("{0}, ({1} duplicate(s))".format(dup, len(rm_elements)))
             print('Removing duplicates and overwriting {}'.format(stdname_file))
             for dup in dup_std_names:
-                first_name = True #Logical that indicates the first of the duplicated names
+                first_use = True #Logical that indicates the first use of the duplicated name
                 rm_parents = root.findall('./section/standard_name[@name="%s"]..'%dup)
                 for par in rm_parents:
                     rm_ele = par.findall('./standard_name[@name="%s"]'%dup)
                     for ele in rm_ele:
-                        if first_name:
-                            #Now all future names will be removed:
-                            first_name = False
+                        if first_use:
+                            #Now all future uses of the name will be removed:
+                            first_use = False
                         else:
                             par.remove(ele)
             #Overwrite the xml file with the new, duplicate-free element tree:

--- a/xml_tools.py
+++ b/xml_tools.py
@@ -47,8 +47,7 @@ def call_command(commands, logger, silent=False):
         if PY3:
             if PYSUBVER > 6:
                 cproc = subprocess.run(commands, check=True,
-                                       capture_output=True,
-                                       stderr=subprocess.STDOUT)
+                                       capture_output=True)
                 if not silent:
                     logger.debug(cproc.stdout)
                 # end if


### PR DESCRIPTION
This PR modifies the xml_tools library to allow the use of python 3.7+ when using `write_standard_name_table.py`.  Also fixed the use of the `--overwrite` flag in `check_xml_unique.py`.

Fixes #30 
Fixes #31 

### Tests run:

Ran tests with `check_xml_unique.py` and `check_xml_unique.py --overwrite` where duplicate variables were added to both the same section and to different sections of `standard_names.xml`, to make sure the script worked as expected.

Also ran `write_standard_name_table.py` on a modified `standard_names.xml` file to make sure the Markdown file was created successfully.  This was done with python 3.9.4, 3.10.8, and 2.7.17 to try and test that the script works with multiple versions, including versions newer than 3.6.

Finally, I again wasn't sure who to add as reviewers, so please feel free to expand or modify the reviewer list if need be.

