### PR TITLE
Add new cloud standard name rule, and update cloud_area_fraction

### DIFF
--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -223,7 +223,7 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = kg m-2
 * `mass_content_of_cloud_liquid_water_in_atmosphere_layer`: Mass content of cloud liquid water in atmosphere layer
     * `real(kind=kind_phys)`: units = kg m-2
-* `non_convective_cloud_area_fraction_in_atmosphere_layer`: cloud area fraction in atmosphere layer excluding clouds produced by the convective schemes
+* `non-convective_cloud_area_fraction_in_atmosphere_layer`: cloud area fraction in atmosphere layer excluding clouds produced by the convective schemes
     * `real(kind=kind_phys)`: units = 1
 * `relative_humidity`: Relative humidity
     * `real(kind=kind_phys)`: units = 1
@@ -802,9 +802,9 @@ Standard / required CCPP variables
     * `integer(kind=)`: units = index
 * `index_of_air_temperature_two_timesteps_back_in_xyz_dimensioned_restart_array`: Index of air temperature two timesteps back in xyz dimensioned restart array
     * `integer(kind=)`: units = index
-* `index_of_non_convective_cloud_area_fraction_in_atmosphere_layer_in_tracer_concentration_array`: Index of non convective cloud area fraction in atmosphere layer in tracer concentration array
+* `index_of_non-convective_cloud_area_fraction_in_atmosphere_layer_in_tracer_concentration_array`: Index of non-convective cloud area fraction in atmosphere layer in tracer concentration array
     * `integer(kind=)`: units = index
-* `index_of_non_convective_cloud_area_fraction_in_atmosphere_layer_in_xyz_dimensioned_restart_array`: Index of non convective cloud area fraction in atmosphere layer in xyz dimensioned restart array
+* `index_of_non-convective_cloud_area_fraction_in_atmosphere_layer_in_xyz_dimensioned_restart_array`: Index of non-convective cloud area fraction in atmosphere layer in xyz dimensioned restart array
     * `integer(kind=)`: units = index
 * `index_of_cloud_liquid_water_effective_radius_in_xyz_dimensioned_restart_array`: Index of cloud liquid water effective radius in xyz dimensioned restart array
     * `integer(kind=)`: units = index
@@ -1967,7 +1967,7 @@ Standard / required CCPP variables
     * `real(kind=kind_phys)`: units = kg kg-1
 * `mass_number_concentration_of_cloud_liquid_water_particles_in_air_of_new_state`: Mass number concentration of cloud liquid water particles in air of new state
     * `real(kind=kind_phys)`: units = kg-1
-* `non_convective_cloud_area_fraction_in_atmosphere_layer_of_new_state`: Non convective cloud area fraction in atmosphere layer of new state
+* `non-convective_cloud_area_fraction_in_atmosphere_layer_of_new_state`: Non-convective cloud area fraction in atmosphere layer of new state
     * `real(kind=kind_phys)`: units = frac
 * `graupel_mixing_ratio_wrt_moist_air_of_new_state`: Graupel mixing ratio wrt moist air of new state
     * `real(kind=kind_phys)`: units = kg kg-1

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -223,7 +223,7 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = kg m-2
 * `mass_content_of_cloud_liquid_water_in_atmosphere_layer`: Mass content of cloud liquid water in atmosphere layer
     * `real(kind=kind_phys)`: units = kg m-2
-* `cloud_area_fraction_in_atmosphere_layer`: Cloud area fraction in atmosphere layer
+* `non_convective_cloud_area_fraction_in_atmosphere_layer`: cloud area fraction in atmosphere layer excluding clouds produced by the convective schemes
     * `real(kind=kind_phys)`: units = 1
 * `relative_humidity`: Relative humidity
     * `real(kind=kind_phys)`: units = 1
@@ -802,9 +802,9 @@ Standard / required CCPP variables
     * `integer(kind=)`: units = index
 * `index_of_air_temperature_two_timesteps_back_in_xyz_dimensioned_restart_array`: Index of air temperature two timesteps back in xyz dimensioned restart array
     * `integer(kind=)`: units = index
-* `index_of_cloud_area_fraction_in_atmosphere_layer_in_tracer_concentration_array`: Index of cloud area fraction in atmosphere layer in tracer concentration array
+* `index_of_non_convective_cloud_area_fraction_in_atmosphere_layer_in_tracer_concentration_array`: Index of non convective cloud area fraction in atmosphere layer in tracer concentration array
     * `integer(kind=)`: units = index
-* `index_of_cloud_area_fraction_in_atmosphere_layer_in_xyz_dimensioned_restart_array`: Index of cloud area fraction in atmosphere layer in xyz dimensioned restart array
+* `index_of_non_convective_cloud_area_fraction_in_atmosphere_layer_in_xyz_dimensioned_restart_array`: Index of non convective cloud area fraction in atmosphere layer in xyz dimensioned restart array
     * `integer(kind=)`: units = index
 * `index_of_cloud_liquid_water_effective_radius_in_xyz_dimensioned_restart_array`: Index of cloud liquid water effective radius in xyz dimensioned restart array
     * `integer(kind=)`: units = index
@@ -1967,7 +1967,7 @@ Standard / required CCPP variables
     * `real(kind=kind_phys)`: units = kg kg-1
 * `mass_number_concentration_of_cloud_liquid_water_particles_in_air_of_new_state`: Mass number concentration of cloud liquid water particles in air of new state
     * `real(kind=kind_phys)`: units = kg-1
-* `cloud_area_fraction_in_atmosphere_layer_of_new_state`: Cloud area fraction in atmosphere layer of new state
+* `non_convective_cloud_area_fraction_in_atmosphere_layer_of_new_state`: Non convective cloud area fraction in atmosphere layer of new state
     * `real(kind=kind_phys)`: units = frac
 * `graupel_mixing_ratio_wrt_moist_air_of_new_state`: Graupel mixing ratio wrt moist air of new state
     * `real(kind=kind_phys)`: units = kg kg-1

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -223,7 +223,7 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = kg m-2
 * `mass_content_of_cloud_liquid_water_in_atmosphere_layer`: Mass content of cloud liquid water in atmosphere layer
     * `real(kind=kind_phys)`: units = kg m-2
-* `non-convective_cloud_area_fraction_in_atmosphere_layer`: cloud area fraction in atmosphere layer excluding clouds produced by the convective schemes
+* `nonconvective_cloud_area_fraction_in_atmosphere_layer`: cloud area fraction in atmosphere layer excluding clouds produced by the convective schemes
     * `real(kind=kind_phys)`: units = 1
 * `relative_humidity`: Relative humidity
     * `real(kind=kind_phys)`: units = 1
@@ -802,9 +802,9 @@ Standard / required CCPP variables
     * `integer(kind=)`: units = index
 * `index_of_air_temperature_two_timesteps_back_in_xyz_dimensioned_restart_array`: Index of air temperature two timesteps back in xyz dimensioned restart array
     * `integer(kind=)`: units = index
-* `index_of_non-convective_cloud_area_fraction_in_atmosphere_layer_in_tracer_concentration_array`: Index of non-convective cloud area fraction in atmosphere layer in tracer concentration array
+* `index_of_nonconvective_cloud_area_fraction_in_atmosphere_layer_in_tracer_concentration_array`: Index of nonconvective cloud area fraction in atmosphere layer in tracer concentration array
     * `integer(kind=)`: units = index
-* `index_of_non-convective_cloud_area_fraction_in_atmosphere_layer_in_xyz_dimensioned_restart_array`: Index of non-convective cloud area fraction in atmosphere layer in xyz dimensioned restart array
+* `index_of_nonconvective_cloud_area_fraction_in_atmosphere_layer_in_xyz_dimensioned_restart_array`: Index of nonconvective cloud area fraction in atmosphere layer in xyz dimensioned restart array
     * `integer(kind=)`: units = index
 * `index_of_cloud_liquid_water_effective_radius_in_xyz_dimensioned_restart_array`: Index of cloud liquid water effective radius in xyz dimensioned restart array
     * `integer(kind=)`: units = index
@@ -1967,7 +1967,7 @@ Standard / required CCPP variables
     * `real(kind=kind_phys)`: units = kg kg-1
 * `mass_number_concentration_of_cloud_liquid_water_particles_in_air_of_new_state`: Mass number concentration of cloud liquid water particles in air of new state
     * `real(kind=kind_phys)`: units = kg-1
-* `non-convective_cloud_area_fraction_in_atmosphere_layer_of_new_state`: Non-convective cloud area fraction in atmosphere layer of new state
+* `nonconvective_cloud_area_fraction_in_atmosphere_layer_of_new_state`: Nonconvective cloud area fraction in atmosphere layer of new state
     * `real(kind=kind_phys)`: units = frac
 * `graupel_mixing_ratio_wrt_moist_air_of_new_state`: Graupel mixing ratio wrt moist air of new state
     * `real(kind=kind_phys)`: units = kg kg-1

--- a/StandardNamesRules.rst
+++ b/StandardNamesRules.rst
@@ -86,6 +86,12 @@ CCPP Standard Name Rules
    Otherwise the standard name should explicitly state the type of hydrometeor(s) the
    named quantity represents (e.g. *graupel*).
 
+#. By default, the term *cloud* refers to all cloud phases and cloud types. Otherwise
+   an additional prefix or suffix should be added to the standard name specifying what kind(s)
+   of clouds the variable repesents (e.g. *ice_cloud* if only including glaciated clouds, or
+   *cloud_from_convective_scheme* if only including clouds produced by the parameterized
+   convection physics scheme).
+
 #. If possible, qualifiers should be limited in order to allow for a wide
    applicability of the variable. In other words, don't qualify with _for ``_xyz``
    unless a variable could not conceivably be used outside of the more

--- a/StandardNamesRules.rst
+++ b/StandardNamesRules.rst
@@ -89,8 +89,7 @@ CCPP Standard Name Rules
 #. By default, the term *cloud* refers to all cloud phases and cloud types. Otherwise
    an additional prefix or suffix should be added to the standard name specifying what kind(s)
    of clouds the variable repesents (e.g. *ice_cloud* if only including glaciated clouds, or
-   *convective_cloud* if only including clouds produced by the parameterized convection
-   physics scheme).
+   *cloud_at_500hPa* if only including clouds that exist at 500 hPa).
 
 #. If possible, qualifiers should be limited in order to allow for a wide
    applicability of the variable. In other words, don't qualify with _for ``_xyz``

--- a/StandardNamesRules.rst
+++ b/StandardNamesRules.rst
@@ -89,8 +89,8 @@ CCPP Standard Name Rules
 #. By default, the term *cloud* refers to all cloud phases and cloud types. Otherwise
    an additional prefix or suffix should be added to the standard name specifying what kind(s)
    of clouds the variable repesents (e.g. *ice_cloud* if only including glaciated clouds, or
-   *cloud_from_convective_scheme* if only including clouds produced by the parameterized
-   convection physics scheme).
+   *convective_cloud* if only including clouds produced by the parameterized convection
+   physics scheme).
 
 #. If possible, qualifiers should be limited in order to allow for a wide
    applicability of the variable. In other words, don't qualify with _for ``_xyz``

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -354,7 +354,9 @@
     <standard_name name="mass_content_of_cloud_liquid_water_in_atmosphere_layer">
       <type kind="kind_phys" units="kg m-2">real</type>
     </standard_name>
-    <standard_name name="cloud_area_fraction_in_atmosphere_layer">
+    <standard_name
+        name="non_convective_cloud_area_fraction_in_atmosphere_layer"
+        long_name="cloud area fraction in atmosphere layer excluding clouds produced by the convective schemes">
       <type kind="kind_phys" units="1">real</type>
     </standard_name>
     <standard_name name="relative_humidity">
@@ -1241,10 +1243,10 @@
       <standard_name name="index_of_air_temperature_two_timesteps_back_in_xyz_dimensioned_restart_array">
          <type kind="" units="index">integer</type>
       </standard_name>
-      <standard_name name="index_of_cloud_area_fraction_in_atmosphere_layer_in_tracer_concentration_array">
+      <standard_name name="index_of_non_convective_cloud_area_fraction_in_atmosphere_layer_in_tracer_concentration_array">
          <type kind="" units="index">integer</type>
       </standard_name>
-      <standard_name name="index_of_cloud_area_fraction_in_atmosphere_layer_in_xyz_dimensioned_restart_array">
+      <standard_name name="index_of_non_convective_cloud_area_fraction_in_atmosphere_layer_in_xyz_dimensioned_restart_array">
          <type kind="" units="index">integer</type>
       </standard_name>
       <standard_name name="index_of_cloud_liquid_water_effective_radius_in_xyz_dimensioned_restart_array">
@@ -2993,7 +2995,7 @@
       <standard_name name="mass_number_concentration_of_cloud_liquid_water_particles_in_air_of_new_state">
          <type kind="kind_phys" units="kg-1">real</type>
       </standard_name>
-      <standard_name name="cloud_area_fraction_in_atmosphere_layer_of_new_state">
+      <standard_name name="non_convective_cloud_area_fraction_in_atmosphere_layer_of_new_state">
          <type kind="kind_phys" units="frac">real</type>
       </standard_name>
       <standard_name name="graupel_mixing_ratio_wrt_moist_air_of_new_state">

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -355,7 +355,7 @@
       <type kind="kind_phys" units="kg m-2">real</type>
     </standard_name>
     <standard_name
-        name="non_convective_cloud_area_fraction_in_atmosphere_layer"
+        name="non-convective_cloud_area_fraction_in_atmosphere_layer"
         long_name="cloud area fraction in atmosphere layer excluding clouds produced by the convective schemes">
       <type kind="kind_phys" units="1">real</type>
     </standard_name>
@@ -1243,10 +1243,10 @@
       <standard_name name="index_of_air_temperature_two_timesteps_back_in_xyz_dimensioned_restart_array">
          <type kind="" units="index">integer</type>
       </standard_name>
-      <standard_name name="index_of_non_convective_cloud_area_fraction_in_atmosphere_layer_in_tracer_concentration_array">
+      <standard_name name="index_of_non-convective_cloud_area_fraction_in_atmosphere_layer_in_tracer_concentration_array">
          <type kind="" units="index">integer</type>
       </standard_name>
-      <standard_name name="index_of_non_convective_cloud_area_fraction_in_atmosphere_layer_in_xyz_dimensioned_restart_array">
+      <standard_name name="index_of_non-convective_cloud_area_fraction_in_atmosphere_layer_in_xyz_dimensioned_restart_array">
          <type kind="" units="index">integer</type>
       </standard_name>
       <standard_name name="index_of_cloud_liquid_water_effective_radius_in_xyz_dimensioned_restart_array">
@@ -2995,7 +2995,7 @@
       <standard_name name="mass_number_concentration_of_cloud_liquid_water_particles_in_air_of_new_state">
          <type kind="kind_phys" units="kg-1">real</type>
       </standard_name>
-      <standard_name name="non_convective_cloud_area_fraction_in_atmosphere_layer_of_new_state">
+      <standard_name name="non-convective_cloud_area_fraction_in_atmosphere_layer_of_new_state">
          <type kind="kind_phys" units="frac">real</type>
       </standard_name>
       <standard_name name="graupel_mixing_ratio_wrt_moist_air_of_new_state">

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -355,7 +355,7 @@
       <type kind="kind_phys" units="kg m-2">real</type>
     </standard_name>
     <standard_name
-        name="non-convective_cloud_area_fraction_in_atmosphere_layer"
+        name="nonconvective_cloud_area_fraction_in_atmosphere_layer"
         long_name="cloud area fraction in atmosphere layer excluding clouds produced by the convective schemes">
       <type kind="kind_phys" units="1">real</type>
     </standard_name>
@@ -1243,10 +1243,10 @@
       <standard_name name="index_of_air_temperature_two_timesteps_back_in_xyz_dimensioned_restart_array">
          <type kind="" units="index">integer</type>
       </standard_name>
-      <standard_name name="index_of_non-convective_cloud_area_fraction_in_atmosphere_layer_in_tracer_concentration_array">
+      <standard_name name="index_of_nonconvective_cloud_area_fraction_in_atmosphere_layer_in_tracer_concentration_array">
          <type kind="" units="index">integer</type>
       </standard_name>
-      <standard_name name="index_of_non-convective_cloud_area_fraction_in_atmosphere_layer_in_xyz_dimensioned_restart_array">
+      <standard_name name="index_of_nonconvective_cloud_area_fraction_in_atmosphere_layer_in_xyz_dimensioned_restart_array">
          <type kind="" units="index">integer</type>
       </standard_name>
       <standard_name name="index_of_cloud_liquid_water_effective_radius_in_xyz_dimensioned_restart_array">
@@ -2995,7 +2995,7 @@
       <standard_name name="mass_number_concentration_of_cloud_liquid_water_particles_in_air_of_new_state">
          <type kind="kind_phys" units="kg-1">real</type>
       </standard_name>
-      <standard_name name="non-convective_cloud_area_fraction_in_atmosphere_layer_of_new_state">
+      <standard_name name="nonconvective_cloud_area_fraction_in_atmosphere_layer_of_new_state">
          <type kind="kind_phys" units="frac">real</type>
       </standard_name>
       <standard_name name="graupel_mixing_ratio_wrt_moist_air_of_new_state">


### PR DESCRIPTION
This pull request adds a new rule specifying that unless stated otherwise, the word `cloud` means all cloud phases and types.

Also, it was brought up by @grantfirl That the standard name `cloud_area_fraction` as used in the UFS doesn't include convective clouds, so the standard name was updated, along with standard names that appeared directly related, to specify that convective clouds are not included.

Finally, I am not strongly tied to the specific wording of either the new rule or the updated standard names, and so am happy to change them to whatever people prefer.