### PR TITLE
Fix typo in standard names

### DIFF
--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -1274,7 +1274,7 @@ Standard / required CCPP variables
     * `real(kind=kind_phys)`: units = m
 * `specific_humidity_on_previous_timestep`: Specific humidity on previous timestep
     * `real(kind=kind_phys)`: units = kg kg-1
-* `tendendy_of_specific_humidity_due_to_nonphysics`: Tendendy of specific humidity due to nonphysics
+* `tendency_of_specific_humidity_due_to_nonphysics`: Tendency of specific humidity due to nonphysics
     * `real(kind=kind_phys)`: units = kg kg-1 s-1
 * `momentum_exchange_coefficient_for_myj_schemes`: Momentum exchange coefficient for myj schemes
     * `real(kind=kind_phys)`: units = m s-1

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -1954,7 +1954,7 @@
       <standard_name name="specific_humidity_on_previous_timestep">
          <type kind="kind_phys" units="kg kg-1">real</type>
       </standard_name>
-      <standard_name name="tendendy_of_specific_humidity_due_to_nonphysics">
+      <standard_name name="tendency_of_specific_humidity_due_to_nonphysics">
          <type kind="kind_phys" units="kg kg-1 s-1">real</type>
       </standard_name>
       <standard_name name="momentum_exchange_coefficient_for_myj_schemes">


### PR DESCRIPTION
In looking through some documentation updates, I noticed a typo in one of the standard names: "tendency" was written as "tendendy". This PR fixes this typo in the places it occurs.

