### PR TITLE
Adding atmospheric composition variables for JCSDA needs

### DIFF
--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -5,7 +5,7 @@
 * [coordinates](#coordinates)
 * [state_variables](#state_variables)
 * [diagnostics](#diagnostics)
-* [constituents](#constituents)
+* [atmospheric composition](#atmospheric_composition)
 * [standard_variables](#standard_variables)
 * [GFS_typedefs_GFS_control_type](#GFS_typedefs_GFS_control_type)
 * [GFS_typedefs_GFS_interstitial_type](#GFS_typedefs_GFS_interstitial_type)
@@ -230,20 +230,17 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
 ## diagnostics
 * `total_precipitation_rate_at_surface`: Total precipitation rate at surface
     * `real(kind=kind_phys)`: units = m s-1
-## constituents
+## atmospheric_composition
 * `number_of_chemical_species`: Number of chemical species
     * `integer(kind=kind_phys)`: units = count
 * `number_of_tracers`: Number of tracers
     * `integer(kind=kind_phys)`: units = count
+#### water
 * `water_vapor_mixing_ratio_wrt_moist_air`: Ratio of the mass of water vapor to the mass of moist air
     * `real(kind=kind_phys)`: units = kg kg-1
 * `water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water`: Ratio of the mass of water vapor to the mass of moist air and hydrometeors
     * `real(kind=kind_phys)`: units = kg kg-1
 * `mole_fraction_of_water_vapor`: Mole fraction of water vapor
-    * `real(kind=kind_phys)`: units = mol mol-1
-* `mole_fraction_of_ozone_in_air`: Mole fraction of ozone in air
-    * `real(kind=kind_phys)`: units = mol mol-1
-* `mole_fraction_of_carbon_dioxide_in_air`: Mole fraction of carbon dioxide in air
     * `real(kind=kind_phys)`: units = mol mol-1
 * `water_vapor_mixing_ratio_wrt_dry_air`: Ratio of the mass of water vapor to the mass of dry air
     * `real(kind=kind_phys)`: units = kg kg-1
@@ -255,6 +252,11 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = kg kg-1
 * `rain_mixing_ratio_wrt_moist_air`: ratio of the mass of rain to the mass of moist air
     * `real(kind=kind_phys)`: units = kg kg-1
+#### trace gas
+* `mole_fraction_of_ozone_in_air`: Mole fraction of ozone in air
+    * `real(kind=kind_phys)`: units = mol mol-1
+* `mole_fraction_of_carbon_dioxide_in_air`: Mole fraction of carbon dioxide in air
+    * `real(kind=kind_phys)`: units = mol mol-1
 * `volume_mixing_ratio_of_ch4`: CH4 volume mixing ratio
     * `real(kind=kind_phys)`: units = mol mol-1
 * `volume_mixing_ratio_of_co`: CO volume mixing ratio
@@ -275,6 +277,18 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = mol mol-1
 * `volume_mixing_ratio_of_n2o`: N2O volume mixing ratio
     * `real(kind=kind_phys)`: units = mol mol-1
+* `volume_mixing_ratio_of_no2`: NO2 volume mixing ratio
+    * `real(kind=kind_phys)`: units = mol mol-1
+* `volume_mixing_ratio_of_no`: NO volume mixing ratio
+    * `real(kind=kind_phys)`: units = mol mol-1
+* `volume_mixing_ratio_of_hcho`: HCHO volume mixing ratio
+    * `real(kind=kind_phys)`: units = mol mol-1
+* `volume_mixing_ratio_of_c5h8`: C5H8 volume mixing ratio
+    * `real(kind=kind_phys)`: units = mol mol-1
+* `volume_mixing_ratio_of_so2`: SO2 volume mixing ratio
+    * `real(kind=kind_phys)`: units = mol mol-1
+#### aerosols
+
 ## standard_variables
 Standard / required CCPP variables
 * `ccpp_error_message`: Error message for error handling in CCPP

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -5,7 +5,7 @@
 * [coordinates](#coordinates)
 * [state_variables](#state_variables)
 * [diagnostics](#diagnostics)
-* [atmospheric composition](#atmospheric composition)
+* [atmospheric_composition](#atmospheric_composition)
 * [standard_variables](#standard_variables)
 * [GFS_typedefs_GFS_control_type](#GFS_typedefs_GFS_control_type)
 * [GFS_typedefs_GFS_interstitial_type](#GFS_typedefs_GFS_interstitial_type)
@@ -230,7 +230,7 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
 ## diagnostics
 * `total_precipitation_rate_at_surface`: Total precipitation rate at surface
     * `real(kind=kind_phys)`: units = m s-1
-## atmospheric composition
+## atmospheric_composition
 * `number_of_chemical_species`: Number of chemical species
     * `integer(kind=kind_phys)`: units = count
 * `number_of_tracers`: Number of tracers

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -262,7 +262,7 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = mol mol-1
 * `volume_mixing_ratio_of_co2`: Carbon dioxide volume mixing ratio
     * `real(kind=kind_phys)`: units = mol mol-1
-* `volume_mixing_ratio_of_ccl4`: CCL4 volume mixing ratio
+* `volume_mixing_ratio_of_ccl4`: Tetrachloromethane volume mixing ratio
     * `real(kind=kind_phys)`: units = mol mol-1
 * `volume_mixing_ratio_of_cfc11`: Trichlorofluoromethane volume mixing ratio
     * `real(kind=kind_phys)`: units = mol mol-1

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -308,6 +308,23 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = kg kg-1
 * `mass_fraction_of_sea_salt005_in_air`: Sea Salt bin5 mass fraction
     * `real(kind=kind_phys)`: units = kg kg-1
+* `mass_fraction_of_hydrophobic_black_carbon_in_air`: Hydrophobic black carbon mass fraction
+    * `real(kind=kind_phys)`: units = kg kg-1
+* `mass_fraction_of_hydrophilic_black_carbon_in_air`: Hydrophilic black carbon mass fraction
+    * `real(kind=kind_phys)`: units = kg kg-1
+* `mass_fraction_of_hydrophobic_organic_carbon_in_air`: Hydrophobic organic carbon mass fraction
+    * `real(kind=kind_phys)`: units = kg kg-1
+* `mass_fraction_of_hydrophilic_organic_carbon_in_air`: Hydrophilic organic carbon mass fraction
+    * `real(kind=kind_phys)`: units = kg kg-1
+* `mass_fraction_of_sulfate_in_air`: Sulfate mass fraction
+    * `real(kind=kind_phys)`: units = kg kg-1
+* `mass_fraction_of_nitrate001_in_air`: Nitrate bin1 mass fraction
+    * `real(kind=kind_phys)`: units = kg kg-1
+* `mass_fraction_of_nitrate002_in_air`: Nitrate bin2 mass fraction
+    * `real(kind=kind_phys)`: units = kg kg-1
+* `mass_fraction_of_nitrate003_in_air`: Nitrate bin3 mass fraction
+    * `real(kind=kind_phys)`: units = kg kg-1
+
 
 ## standard_variables
 Standard / required CCPP variables

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -5,7 +5,7 @@
 * [coordinates](#coordinates)
 * [state_variables](#state_variables)
 * [diagnostics](#diagnostics)
-* [atmospheric composition](#atmospheric_composition)
+* [atmospheric composition](#atmospheric composition)
 * [standard_variables](#standard_variables)
 * [GFS_typedefs_GFS_control_type](#GFS_typedefs_GFS_control_type)
 * [GFS_typedefs_GFS_interstitial_type](#GFS_typedefs_GFS_interstitial_type)
@@ -230,12 +230,11 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
 ## diagnostics
 * `total_precipitation_rate_at_surface`: Total precipitation rate at surface
     * `real(kind=kind_phys)`: units = m s-1
-## atmospheric_composition
+## atmospheric composition
 * `number_of_chemical_species`: Number of chemical species
     * `integer(kind=kind_phys)`: units = count
 * `number_of_tracers`: Number of tracers
     * `integer(kind=kind_phys)`: units = count
-#### water
 * `water_vapor_mixing_ratio_wrt_moist_air`: Ratio of the mass of water vapor to the mass of moist air
     * `real(kind=kind_phys)`: units = kg kg-1
 * `water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water`: Ratio of the mass of water vapor to the mass of moist air and hydrometeors
@@ -252,7 +251,6 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = kg kg-1
 * `rain_mixing_ratio_wrt_moist_air`: ratio of the mass of rain to the mass of moist air
     * `real(kind=kind_phys)`: units = kg kg-1
-#### trace gas
 * `mole_fraction_of_ozone_in_air`: Mole fraction of ozone in air
     * `real(kind=kind_phys)`: units = mol mol-1
 * `mole_fraction_of_carbon_dioxide_in_air`: Mole fraction of carbon dioxide in air
@@ -281,13 +279,14 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = mol mol-1
 * `volume_mixing_ratio_of_no`: NO volume mixing ratio
     * `real(kind=kind_phys)`: units = mol mol-1
+* `volume_mixing_ratio_of_o3`: O3 volume mixing ratio
+    * `real(kind=kind_phys)`: units = mol mol-1
 * `volume_mixing_ratio_of_hcho`: HCHO volume mixing ratio
     * `real(kind=kind_phys)`: units = mol mol-1
 * `volume_mixing_ratio_of_c5h8`: C5H8 volume mixing ratio
     * `real(kind=kind_phys)`: units = mol mol-1
 * `volume_mixing_ratio_of_so2`: SO2 volume mixing ratio
     * `real(kind=kind_phys)`: units = mol mol-1
-#### aerosols
 * `mass_fraction_of_dust001_in_air`: Dust bin1 mass fraction
     * `real(kind=kind_phys)`: units = kg kg-1
 * `mass_fraction_of_dust002_in_air`: Dust bin2 mass fraction
@@ -298,35 +297,38 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = kg kg-1
 * `mass_fraction_of_dust005_in_air`: Dust bin5 mass fraction
     * `real(kind=kind_phys)`: units = kg kg-1
-* `mass_fraction_of_sea_salt001_in_air`: Sea Salt bin1 mass fraction
+* `mass_fraction_of_sea_salt001_in_air`: Sea salt bin5 mass fraction
     * `real(kind=kind_phys)`: units = kg kg-1
-* `mass_fraction_of_sea_salt002_in_air`: Sea Salt bin2 mass fraction
+* `mass_fraction_of_sea_salt002_in_air`: Sea salt bin2 mass fraction
     * `real(kind=kind_phys)`: units = kg kg-1
-* `mass_fraction_of_sea_salt003_in_air`: Sea Salt bin3 mass fraction
+* `mass_fraction_of_sea_salt003_in_air`: Sea salt bin3 mass fraction
     * `real(kind=kind_phys)`: units = kg kg-1
-* `mass_fraction_of_sea_salt004_in_air`: Sea Salt bin4 mass fraction
+* `mass_fraction_of_sea_salt004_in_air`: Sea salt bin4 mass fraction
     * `real(kind=kind_phys)`: units = kg kg-1
-* `mass_fraction_of_sea_salt005_in_air`: Sea Salt bin5 mass fraction
+* `mass_fraction_of_sea_salt005_in_air`: Sea salt bin5 mass fraction
     * `real(kind=kind_phys)`: units = kg kg-1
 * `mass_fraction_of_hydrophobic_black_carbon_in_air`: Hydrophobic black carbon mass fraction
     * `real(kind=kind_phys)`: units = kg kg-1
 * `mass_fraction_of_hydrophilic_black_carbon_in_air`: Hydrophilic black carbon mass fraction
     * `real(kind=kind_phys)`: units = kg kg-1
-* `mass_fraction_of_hydrophobic_organic_carbon_in_air`: Hydrophobic organic carbon mass fraction
+* `mass_fraction_of_hydrophobic_organic_carbon_in_air`: Hydrophobic black carbon mass fraction
     * `real(kind=kind_phys)`: units = kg kg-1
-* `mass_fraction_of_hydrophilic_organic_carbon_in_air`: Hydrophilic organic carbon mass fraction
+* `mass_fraction_of_hydrophilic_organic_carbon_in_air`: Hydrophilic black carbon mass fraction
     * `real(kind=kind_phys)`: units = kg kg-1
 * `mass_fraction_of_sulfate_in_air`: Sulfate mass fraction
     * `real(kind=kind_phys)`: units = kg kg-1
-* `mass_fraction_of_nitrate001_in_air`: Nitrate bin1 mass fraction
+* `mass_fraction_of_sea_nitratet001_in_air`: Nitrate bin1 mass fraction
     * `real(kind=kind_phys)`: units = kg kg-1
-* `mass_fraction_of_nitrate002_in_air`: Nitrate bin2 mass fraction
+* `mass_fraction_of_sea_nitratet002_in_air`: Nitrate bin2 mass fraction
     * `real(kind=kind_phys)`: units = kg kg-1
-* `mass_fraction_of_nitrate003_in_air`: Nitrate bin3 mass fraction
+* `mass_fraction_of_sea_nitratet003_in_air`: Nitrate bin3 mass fraction
     * `real(kind=kind_phys)`: units = kg kg-1
-* `volume_extinction_in_air_due_to_aerosol_particles`: Aerosol extinction at wavelength
+* `volume_extinction_in_air_due_to_aerosol_particles_lambda1`: Aerosol extinction at wavelength1
     * `real(kind=kind_phys)`: units = m-1
-
+* `volume_extinction_in_air_due_to_aerosol_particles_lambda2`: Aerosol extinction at wavelength2
+    * `real(kind=kind_phys)`: units = m-1
+* `volume_extinction_in_air_due_to_aerosol_particles_lambda3`: Aerosol extinction at wavelength3
+    * `real(kind=kind_phys)`: units = m-1
 ## standard_variables
 Standard / required CCPP variables
 * `ccpp_error_message`: Error message for error handling in CCPP

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -324,7 +324,8 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = kg kg-1
 * `mass_fraction_of_nitrate003_in_air`: Nitrate bin3 mass fraction
     * `real(kind=kind_phys)`: units = kg kg-1
-
+* `volume_extinction_in_air_due_to_aerosol_particles`: Aerosol extinction at wavelength
+    * `real(kind=kind_phys)`: units = m-1
 
 ## standard_variables
 Standard / required CCPP variables

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -311,17 +311,17 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = kg kg-1
 * `mass_fraction_of_hydrophilic_black_carbon_in_air`: Hydrophilic black carbon mass fraction
     * `real(kind=kind_phys)`: units = kg kg-1
-* `mass_fraction_of_hydrophobic_organic_carbon_in_air`: Hydrophobic black carbon mass fraction
+* `mass_fraction_of_hydrophobic_organic_carbon_in_air`: Hydrophobic organic carbon mass fraction
     * `real(kind=kind_phys)`: units = kg kg-1
-* `mass_fraction_of_hydrophilic_organic_carbon_in_air`: Hydrophilic black carbon mass fraction
+* `mass_fraction_of_hydrophilic_organic_carbon_in_air`: Hydrophilic organic carbon mass fraction
     * `real(kind=kind_phys)`: units = kg kg-1
 * `mass_fraction_of_sulfate_in_air`: Sulfate mass fraction
     * `real(kind=kind_phys)`: units = kg kg-1
-* `mass_fraction_of_sea_nitratet001_in_air`: Nitrate bin1 mass fraction
+* `mass_fraction_of_sea_nitrate001_in_air`: Nitrate bin1 mass fraction
     * `real(kind=kind_phys)`: units = kg kg-1
-* `mass_fraction_of_sea_nitratet002_in_air`: Nitrate bin2 mass fraction
+* `mass_fraction_of_sea_nitrate002_in_air`: Nitrate bin2 mass fraction
     * `real(kind=kind_phys)`: units = kg kg-1
-* `mass_fraction_of_sea_nitratet003_in_air`: Nitrate bin3 mass fraction
+* `mass_fraction_of_sea_nitrate003_in_air`: Nitrate bin3 mass fraction
     * `real(kind=kind_phys)`: units = kg kg-1
 * `volume_extinction_in_air_due_to_aerosol_particles_lambda1`: Aerosol extinction at wavelength1
     * `real(kind=kind_phys)`: units = m-1

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -6,6 +6,7 @@
 * [state_variables](#state_variables)
 * [diagnostics](#diagnostics)
 * [atmospheric_composition](#atmospheric_composition)
+* [atmospheric_composition: GOCART aerosols](#atmospheric_composition: GOCART aerosols)
 * [standard_variables](#standard_variables)
 * [GFS_typedefs_GFS_control_type](#GFS_typedefs_GFS_control_type)
 * [GFS_typedefs_GFS_interstitial_type](#GFS_typedefs_GFS_interstitial_type)
@@ -287,6 +288,7 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = mol mol-1
 * `volume_mixing_ratio_of_so2`: SO2 volume mixing ratio
     * `real(kind=kind_phys)`: units = mol mol-1
+## atmospheric_composition: GOCART aerosols
 * `mass_fraction_of_dust001_in_air`: Dust bin1 mass fraction
     * `real(kind=kind_phys)`: units = kg kg-1
 * `mass_fraction_of_dust002_in_air`: Dust bin2 mass fraction

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -256,37 +256,37 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = mol mol-1
 * `mole_fraction_of_carbon_dioxide_in_air`: Mole fraction of carbon dioxide in air
     * `real(kind=kind_phys)`: units = mol mol-1
-* `volume_mixing_ratio_of_ch4`: CH4 volume mixing ratio
+* `volume_mixing_ratio_of_ch4`: Methane volume mixing ratio
     * `real(kind=kind_phys)`: units = mol mol-1
-* `volume_mixing_ratio_of_co`: CO volume mixing ratio
+* `volume_mixing_ratio_of_co`: Carbon monoxide volume mixing ratio
     * `real(kind=kind_phys)`: units = mol mol-1
-* `volume_mixing_ratio_of_co2`: CO2 volume mixing ratio
+* `volume_mixing_ratio_of_co2`: Carbon dioxide volume mixing ratio
     * `real(kind=kind_phys)`: units = mol mol-1
 * `volume_mixing_ratio_of_ccl4`: CCL4 volume mixing ratio
     * `real(kind=kind_phys)`: units = mol mol-1
-* `volume_mixing_ratio_of_cfc11`: CFC11 volume mixing ratio
+* `volume_mixing_ratio_of_cfc11`: Trichlorofluoromethane volume mixing ratio
     * `real(kind=kind_phys)`: units = mol mol-1
-* `volume_mixing_ratio_of_cfc12`: CFC12 volume mixing ratio
+* `volume_mixing_ratio_of_cfc12`: Dichlorodifluoromethane volume mixing ratio
     * `real(kind=kind_phys)`: units = mol mol-1
-* `volume_mixing_ratio_of_cfc113`: CFC113 volume mixing ratio
+* `volume_mixing_ratio_of_cfc113`: 1,1,2-Trichloro-1,2,2-trifluoroethane volume mixing ratio
     * `real(kind=kind_phys)`: units = mol mol-1
-* `volume_mixing_ratio_of_cfc22`: CFC22 volume mixing ratio
+* `volume_mixing_ratio_of_cfc22`: Chlorodifluoromethane volume mixing ratio
     * `real(kind=kind_phys)`: units = mol mol-1
-* `volume_mixing_ratio_of_o2`: O2 volume mixing ratio
+* `volume_mixing_ratio_of_o2`: Dioxygen volume mixing ratio
     * `real(kind=kind_phys)`: units = mol mol-1
-* `volume_mixing_ratio_of_n2o`: N2O volume mixing ratio
+* `volume_mixing_ratio_of_n2o`: Nitrous oxide volume mixing ratio
     * `real(kind=kind_phys)`: units = mol mol-1
-* `volume_mixing_ratio_of_no2`: NO2 volume mixing ratio
+* `volume_mixing_ratio_of_no2`: Nitrogen dioxide volume mixing ratio
     * `real(kind=kind_phys)`: units = mol mol-1
-* `volume_mixing_ratio_of_no`: NO volume mixing ratio
+* `volume_mixing_ratio_of_no`: Nitrogen oxide volume mixing ratio
     * `real(kind=kind_phys)`: units = mol mol-1
-* `volume_mixing_ratio_of_o3`: O3 volume mixing ratio
+* `volume_mixing_ratio_of_o3`: Ozone volume mixing ratio
     * `real(kind=kind_phys)`: units = mol mol-1
-* `volume_mixing_ratio_of_hcho`: HCHO volume mixing ratio
+* `volume_mixing_ratio_of_hcho`: Formaldehyde volume mixing ratio
     * `real(kind=kind_phys)`: units = mol mol-1
-* `volume_mixing_ratio_of_c5h8`: C5H8 volume mixing ratio
+* `volume_mixing_ratio_of_c5h8`: Isoprene volume mixing ratio
     * `real(kind=kind_phys)`: units = mol mol-1
-* `volume_mixing_ratio_of_so2`: SO2 volume mixing ratio
+* `volume_mixing_ratio_of_so2`: Sulfur dioxide volume mixing ratio
     * `real(kind=kind_phys)`: units = mol mol-1
 ## atmospheric_composition: GOCART aerosols
 * `mass_fraction_of_dust001_in_air`: Dust bin1 mass fraction

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -288,6 +288,26 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
 * `volume_mixing_ratio_of_so2`: SO2 volume mixing ratio
     * `real(kind=kind_phys)`: units = mol mol-1
 #### aerosols
+* `mass_fraction_of_dust001_in_air`: Dust bin1 mass fraction
+    * `real(kind=kind_phys)`: units = kg kg-1
+* `mass_fraction_of_dust002_in_air`: Dust bin2 mass fraction
+    * `real(kind=kind_phys)`: units = kg kg-1
+* `mass_fraction_of_dust003_in_air`: Dust bin3 mass fraction
+    * `real(kind=kind_phys)`: units = kg kg-1
+* `mass_fraction_of_dust004_in_air`: Dust bin4 mass fraction
+    * `real(kind=kind_phys)`: units = kg kg-1
+* `mass_fraction_of_dust005_in_air`: Dust bin5 mass fraction
+    * `real(kind=kind_phys)`: units = kg kg-1
+* `mass_fraction_of_sea_salt001_in_air`: Sea Salt bin1 mass fraction
+    * `real(kind=kind_phys)`: units = kg kg-1
+* `mass_fraction_of_sea_salt002_in_air`: Sea Salt bin2 mass fraction
+    * `real(kind=kind_phys)`: units = kg kg-1
+* `mass_fraction_of_sea_salt003_in_air`: Sea Salt bin3 mass fraction
+    * `real(kind=kind_phys)`: units = kg kg-1
+* `mass_fraction_of_sea_salt004_in_air`: Sea Salt bin4 mass fraction
+    * `real(kind=kind_phys)`: units = kg kg-1
+* `mass_fraction_of_sea_salt005_in_air`: Sea Salt bin5 mass fraction
+    * `real(kind=kind_phys)`: units = kg kg-1
 
 ## standard_variables
 Standard / required CCPP variables

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -409,7 +409,7 @@
     <standard_name name="mole_fraction_of_ozone_in_air">
       <type kind="kind_phys" units="mol mol-1">real</type>
     </standard_name>
-    <standard_name name="mole_fraction_of_carbon_dioxide_in_air"
+    <standard_name name="mole_fraction_of_carbon_dioxide_in_air">
       <type kind="kind_phys" units="mol mol-1">real</type>
     </standard_name>
     <standard_name name="volume_mixing_ratio_of_ch4"

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -425,7 +425,7 @@
       <type kind="kind_phys" units="mol mol-1">real</type>
     </standard_name>
     <standard_name name="volume_mixing_ratio_of_ccl4"
-                   long_name="CCL4 volume mixing ratio">
+                   long_name="Tetrachloromethane volume mixing ratio">
       <type kind="kind_phys" units="mol mol-1">real</type>
     </standard_name>
     <standard_name name="volume_mixing_ratio_of_cfc11"

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -476,7 +476,8 @@
                    long_name="SO2 volume mixing ratio">
       <type kind="kind_phys" units="mol mol-1">real</type>
     </standard_name>
-
+  </section>
+    <section name="atmospheric_composition: GOCART aerosols">
     <standard_name name="mass_fraction_of_dust001_in_air"
                    long_name="Dust bin1 mass fraction">
       <type kind="kind_phys" units="kg kg-1">real</type>

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -368,13 +368,15 @@
       <type kind="kind_phys" units="m s-1">real</type>
     </standard_name>
   </section>
-  <section name="constituents">
+  <section name="atmospheric composition">
+
     <standard_name name="number_of_chemical_species">
       <type kind="kind_phys" units="count">integer</type>
     </standard_name>
     <standard_name name="number_of_tracers">
       <type kind="kind_phys" units="count">integer</type>
     </standard_name>
+
     <standard_name name="water_vapor_mixing_ratio_wrt_moist_air"
                    long_name="Ratio of the mass of water vapor to the mass of moist air">
       <type kind="kind_phys" units="kg kg-1">real</type>
@@ -384,12 +386,6 @@
       <type kind="kind_phys" units="kg kg-1">real</type>
     </standard_name>
     <standard_name name="mole_fraction_of_water_vapor">
-      <type kind="kind_phys" units="mol mol-1">real</type>
-    </standard_name>
-    <standard_name name="mole_fraction_of_ozone_in_air">
-      <type kind="kind_phys" units="mol mol-1">real</type>
-    </standard_name>
-    <standard_name name="mole_fraction_of_carbon_dioxide_in_air">
       <type kind="kind_phys" units="mol mol-1">real</type>
     </standard_name>
     <standard_name name="water_vapor_mixing_ratio_wrt_dry_air"
@@ -411,6 +407,13 @@
     <standard_name name="rain_mixing_ratio_wrt_moist_air"
                    long_name="ratio of the mass of rain to the mass of moist air">
       <type kind="kind_phys" units="kg kg-1">real</type>
+    </standard_name>
+
+    <standard_name name="mole_fraction_of_ozone_in_air">
+      <type kind="kind_phys" units="mol mol-1">real</type>
+    </standard_name>
+    <standard_name name="mole_fraction_of_carbon_dioxide_in_air">
+      <type kind="kind_phys" units="mol mol-1">real</type>
     </standard_name>
     <standard_name name="volume_mixing_ratio_of_ch4"
                    long_name="CH4 volume mixing ratio">
@@ -452,6 +455,116 @@
                    long_name="N2O volume mixing ratio">
       <type kind="kind_phys" units="mol mol-1">real</type>
     </standard_name>
+    <standard_name name="volume_mixing_ratio_of_no2"
+                   long_name="NO2 volume mixing ratio">
+      <type kind="kind_phys" units="mol mol-1">real</type>
+    </standard_name>
+    <standard_name name="volume_mixing_ratio_of_no"
+                   long_name="NO volume mixing ratio">
+      <type kind="kind_phys" units="mol mol-1">real</type>
+    </standard_name>
+    <standard_name name="volume_mixing_ratio_of_o3"
+                   long_name="O3 volume mixing ratio">
+      <type kind="kind_phys" units="mol mol-1">real</type>
+    </standard_name>
+    <standard_name name="volume_mixing_ratio_of_hcho"
+                   long_name="HCHO volume mixing ratio">
+      <type kind="kind_phys" units="mol mol-1">real</type>
+    </standard_name>
+    <standard_name name="volume_mixing_ratio_of_c5h8"
+                   long_name="C5H8 volume mixing ratio">
+      <type kind="kind_phys" units="mol mol-1">real</type>
+    </standard_name>
+    <standard_name name="volume_mixing_ratio_of_so2"
+                   long_name="SO2 volume mixing ratio">
+      <type kind="kind_phys" units="mol mol-1">real</type>
+    </standard_name>
+
+    <standard_name name="mass_fraction_of_dust001_in_air"
+                   long_name="Dust bin1 mass fraction">
+      <type kind="kind_phys" units="kg kg-1">real</type>
+    </standard_name>
+    <standard_name name="mass_fraction_of_dust002_in_air"
+                   long_name="Dust bin2 mass fraction">
+      <type kind="kind_phys" units="kg kg-1">real</type>
+    </standard_name>
+    <standard_name name="mass_fraction_of_dust003_in_air"
+                   long_name="Dust bin3 mass fraction">
+      <type kind="kind_phys" units="kg kg-1">real</type>
+    </standard_name>
+    <standard_name name="mass_fraction_of_dust004_in_air"
+                   long_name="Dust bin4 mass fraction">
+      <type kind="kind_phys" units="kg kg-1">real</type>
+    </standard_name>
+    <standard_name name="mass_fraction_of_dust005_in_air"
+                   long_name="Dust bin5 mass fraction">
+      <type kind="kind_phys" units="kg kg-1">real</type>
+    </standard_name>
+    <standard_name name="mass_fraction_of_sea_salt001_in_air"
+                   long_name="Sea salt bin5 mass fraction">
+      <type kind="kind_phys" units="kg kg-1">real</type>
+    </standard_name>
+    <standard_name name="mass_fraction_of_sea_salt002_in_air"
+                   long_name="Sea salt bin2 mass fraction">
+      <type kind="kind_phys" units="kg kg-1">real</type>
+    </standard_name>
+    <standard_name name="mass_fraction_of_sea_salt003_in_air"
+                   long_name="Sea salt bin3 mass fraction">
+      <type kind="kind_phys" units="kg kg-1">real</type>
+    </standard_name>
+    <standard_name name="mass_fraction_of_sea_salt004_in_air"
+                   long_name="Sea salt bin4 mass fraction">
+      <type kind="kind_phys" units="kg kg-1">real</type>
+    </standard_name>
+    <standard_name name="mass_fraction_of_sea_salt005_in_air"
+                   long_name="Sea salt bin5 mass fraction">
+      <type kind="kind_phys" units="kg kg-1">real</type>
+    </standard_name>
+    <standard_name name="mass_fraction_of_hydrophobic_black_carbon_in_air"
+                   long_name="Hydrophobic black carbon mass fraction">
+      <type kind="kind_phys" units="kg kg-1">real</type>
+    </standard_name>
+    <standard_name name="mass_fraction_of_hydrophilic_black_carbon_in_air"
+                   long_name="Hydrophilic black carbon mass fraction">
+      <type kind="kind_phys" units="kg kg-1">real</type>
+    </standard_name>
+    <standard_name name="mass_fraction_of_hydrophobic_organic_carbon_in_air"
+                   long_name="Hydrophobic black carbon mass fraction">
+      <type kind="kind_phys" units="kg kg-1">real</type>
+    </standard_name>
+    <standard_name name="mass_fraction_of_hydrophilic_organic_carbon_in_air"
+                   long_name="Hydrophilic black carbon mass fraction">
+      <type kind="kind_phys" units="kg kg-1">real</type>
+    </standard_name>
+    <standard_name name="mass_fraction_of_sulfate_in_air"
+                   long_name="Sulfate mass fraction">
+      <type kind="kind_phys" units="kg kg-1">real</type>
+    </standard_name>
+    <standard_name name="mass_fraction_of_sea_nitratet001_in_air"
+                   long_name="Nitrate bin1 mass fraction">
+      <type kind="kind_phys" units="kg kg-1">real</type>
+    </standard_name>
+    <standard_name name="mass_fraction_of_sea_nitratet002_in_air"
+                   long_name="Nitrate bin2 mass fraction">
+      <type kind="kind_phys" units="kg kg-1">real</type>
+    </standard_name>
+    <standard_name name="mass_fraction_of_sea_nitratet003_in_air"
+                   long_name="Nitrate bin3 mass fraction">
+      <type kind="kind_phys" units="kg kg-1">real</type>
+    </standard_name>
+    <standard_name name="volume_extinction_in_air_due_to_aerosol_particles_lambda1"
+                   long_name="Aerosol extinction at wavelength1">
+      <type kind="kind_phys" units="m-1">real</type>
+    </standard_name>
+    <standard_name name="volume_extinction_in_air_due_to_aerosol_particles_lambda2"
+                   long_name="Aerosol extinction at wavelength2">
+      <type kind="kind_phys" units="m-1">real</type>
+    </standard_name>
+    <standard_name name="volume_extinction_in_air_due_to_aerosol_particles_lambda3"
+                   long_name="Aerosol extinction at wavelength3">
+      <type kind="kind_phys" units="m-1">real</type>
+    </standard_name>
+
   </section>
   <section name="standard_variables"
            comment="Standard / required CCPP variables">

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -368,7 +368,7 @@
       <type kind="kind_phys" units="m s-1">real</type>
     </standard_name>
   </section>
-  <section name="atmospheric composition">
+  <section name="atmospheric_composition">
 
     <standard_name name="number_of_chemical_species">
       <type kind="kind_phys" units="count">integer</type>

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -369,14 +369,12 @@
     </standard_name>
   </section>
   <section name="atmospheric_composition">
-
     <standard_name name="number_of_chemical_species">
       <type kind="kind_phys" units="count">integer</type>
     </standard_name>
     <standard_name name="number_of_tracers">
       <type kind="kind_phys" units="count">integer</type>
     </standard_name>
-
     <standard_name name="water_vapor_mixing_ratio_wrt_moist_air"
                    long_name="Ratio of the mass of water vapor to the mass of moist air">
       <type kind="kind_phys" units="kg kg-1">real</type>
@@ -408,7 +406,6 @@
                    long_name="ratio of the mass of rain to the mass of moist air">
       <type kind="kind_phys" units="kg kg-1">real</type>
     </standard_name>
-
     <standard_name name="mole_fraction_of_ozone_in_air">
       <type kind="kind_phys" units="mol mol-1">real</type>
     </standard_name>
@@ -529,26 +526,26 @@
       <type kind="kind_phys" units="kg kg-1">real</type>
     </standard_name>
     <standard_name name="mass_fraction_of_hydrophobic_organic_carbon_in_air"
-                   long_name="Hydrophobic black carbon mass fraction">
+                   long_name="Hydrophobic organic carbon mass fraction">
       <type kind="kind_phys" units="kg kg-1">real</type>
     </standard_name>
     <standard_name name="mass_fraction_of_hydrophilic_organic_carbon_in_air"
-                   long_name="Hydrophilic black carbon mass fraction">
+                   long_name="Hydrophilic organic carbon mass fraction">
       <type kind="kind_phys" units="kg kg-1">real</type>
     </standard_name>
     <standard_name name="mass_fraction_of_sulfate_in_air"
                    long_name="Sulfate mass fraction">
       <type kind="kind_phys" units="kg kg-1">real</type>
     </standard_name>
-    <standard_name name="mass_fraction_of_sea_nitratet001_in_air"
+    <standard_name name="mass_fraction_of_sea_nitrate001_in_air"
                    long_name="Nitrate bin1 mass fraction">
       <type kind="kind_phys" units="kg kg-1">real</type>
     </standard_name>
-    <standard_name name="mass_fraction_of_sea_nitratet002_in_air"
+    <standard_name name="mass_fraction_of_sea_nitrate002_in_air"
                    long_name="Nitrate bin2 mass fraction">
       <type kind="kind_phys" units="kg kg-1">real</type>
     </standard_name>
-    <standard_name name="mass_fraction_of_sea_nitratet003_in_air"
+    <standard_name name="mass_fraction_of_sea_nitrate003_in_air"
                    long_name="Nitrate bin3 mass fraction">
       <type kind="kind_phys" units="kg kg-1">real</type>
     </standard_name>
@@ -564,7 +561,6 @@
                    long_name="Aerosol extinction at wavelength3">
       <type kind="kind_phys" units="m-1">real</type>
     </standard_name>
-
   </section>
   <section name="standard_variables"
            comment="Standard / required CCPP variables">

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -409,19 +409,19 @@
     <standard_name name="mole_fraction_of_ozone_in_air">
       <type kind="kind_phys" units="mol mol-1">real</type>
     </standard_name>
-    <standard_name name="mole_fraction_of_carbon_dioxide_in_air">
+    <standard_name name="mole_fraction_of_carbon_dioxide_in_air"
       <type kind="kind_phys" units="mol mol-1">real</type>
     </standard_name>
     <standard_name name="volume_mixing_ratio_of_ch4"
-                   long_name="CH4 volume mixing ratio">
+                   long_name="Methane volume mixing ratio">
       <type kind="kind_phys" units="mol mol-1">real</type>
     </standard_name>
     <standard_name name="volume_mixing_ratio_of_co"
-                   long_name="CO volume mixing ratio">
+                   long_name="Carbon monoxide volume mixing ratio">
       <type kind="kind_phys" units="mol mol-1">real</type>
     </standard_name>
     <standard_name name="volume_mixing_ratio_of_co2"
-                   long_name="CO2 volume mixing ratio">
+                   long_name="Carbon dioxide volume mixing ratio">
       <type kind="kind_phys" units="mol mol-1">real</type>
     </standard_name>
     <standard_name name="volume_mixing_ratio_of_ccl4"
@@ -429,51 +429,51 @@
       <type kind="kind_phys" units="mol mol-1">real</type>
     </standard_name>
     <standard_name name="volume_mixing_ratio_of_cfc11"
-                   long_name="CFC11 volume mixing ratio">
+                   long_name="Trichlorofluoromethane volume mixing ratio">
       <type kind="kind_phys" units="mol mol-1">real</type>
     </standard_name>
     <standard_name name="volume_mixing_ratio_of_cfc12"
-                   long_name="CFC12 volume mixing ratio">
+                   long_name="Dichlorodifluoromethane volume mixing ratio">
       <type kind="kind_phys" units="mol mol-1">real</type>
     </standard_name>
     <standard_name name="volume_mixing_ratio_of_cfc113"
-                   long_name="CFC113 volume mixing ratio">
+                   long_name="1,1,2-Trichloro-1,2,2-trifluoroethane volume mixing ratio">
       <type kind="kind_phys" units="mol mol-1">real</type>
     </standard_name>
     <standard_name name="volume_mixing_ratio_of_cfc22"
-                   long_name="CFC22 volume mixing ratio">
+                   long_name="Chlorodifluoromethane volume mixing ratio">
       <type kind="kind_phys" units="mol mol-1">real</type>
     </standard_name>
     <standard_name name="volume_mixing_ratio_of_o2"
-                   long_name="O2 volume mixing ratio">
+                   long_name="Dioxygen volume mixing ratio">
       <type kind="kind_phys" units="mol mol-1">real</type>
     </standard_name>
     <standard_name name="volume_mixing_ratio_of_n2o"
-                   long_name="N2O volume mixing ratio">
+                   long_name="Nitrous oxide volume mixing ratio">
       <type kind="kind_phys" units="mol mol-1">real</type>
     </standard_name>
     <standard_name name="volume_mixing_ratio_of_no2"
-                   long_name="NO2 volume mixing ratio">
+                   long_name="Nitrogen dioxide volume mixing ratio">
       <type kind="kind_phys" units="mol mol-1">real</type>
     </standard_name>
     <standard_name name="volume_mixing_ratio_of_no"
-                   long_name="NO volume mixing ratio">
+                   long_name="Nitrogen oxide volume mixing ratio">
       <type kind="kind_phys" units="mol mol-1">real</type>
     </standard_name>
     <standard_name name="volume_mixing_ratio_of_o3"
-                   long_name="O3 volume mixing ratio">
+                   long_name="Ozone volume mixing ratio">
       <type kind="kind_phys" units="mol mol-1">real</type>
     </standard_name>
     <standard_name name="volume_mixing_ratio_of_hcho"
-                   long_name="HCHO volume mixing ratio">
+                   long_name="Formaldehyde volume mixing ratio">
       <type kind="kind_phys" units="mol mol-1">real</type>
     </standard_name>
     <standard_name name="volume_mixing_ratio_of_c5h8"
-                   long_name="C5H8 volume mixing ratio">
+                   long_name="Isoprene volume mixing ratio">
       <type kind="kind_phys" units="mol mol-1">real</type>
     </standard_name>
     <standard_name name="volume_mixing_ratio_of_so2"
-                   long_name="SO2 volume mixing ratio">
+                   long_name="Sulfur dioxide volume mixing ratio">
       <type kind="kind_phys" units="mol mol-1">real</type>
     </standard_name>
   </section>


### PR DESCRIPTION
Adding atmospheric composition variables for JCSDA needs.
I took the freedom to change constituent to atmospheric composition as this is a more generic term and is now more widely used in the scientific community,
I reordered this section as follows:
- variable counts
- water
- trace gas
- aerosols 

It would have been better to put them in XML subsections but the python script doesn't allow this. I could however update the python script in a different PR if we think the subsections are really needed. 

Note that there redundancies in certain quantities such as for O3 and CO2 as volume mixing ratio and mole fraction is the same. I understand that some models especially on the meteorology side have O3 and CO2 concentrations as mole fractions but the chemistry modules as volume mixing ratios. Both should be kept to satisfy the needs but we should try to limit the redundancies as much as possible.