### PR TITLE
Add including_point_above_model_top --> extended_up_by_1 suffix

### DIFF
--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -162,6 +162,8 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = 1
 * `ln_air_pressure_of_dry_air_at_interface`: Ln air pressure of dry air at interface
     * `real(kind=kind_phys)`: units = 1
+* `air_pressure_including_point_above_model_top`: Air pressure including point above model top
+    * `real(kind=kind_phys)`: units = Pa
 * `largest_model_top_pressure_that_allows_molecular_diffusion`: Largest model top pressure that allows molecular diffusion
     * `real(kind=kind_phys)`: units = Pa
 * `do_molecular_diffusion`: Do molecular diffusion

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -42,6 +42,8 @@ Currently, the only dimension which supports all six dimension types is horizont
     * `integer`: units = count
 * `vertical_layer_dimension`: number of vertical layers
     * `integer`: units = count
+* `vertical_layer_dimension_extended_up_by_1`: number of vertical layers extended up by 1
+    * `integer`: units = count
 * `vertical_interface_dimension`: number of vertical interfaces
     * `integer`: units = count
 * `vertical_layer_index`: index of a particular vertical layer
@@ -162,7 +164,7 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = 1
 * `ln_air_pressure_of_dry_air_at_interface`: Ln air pressure of dry air at interface
     * `real(kind=kind_phys)`: units = 1
-* `air_pressure_including_point_above_model_top`: Air pressure including point above model top
+* `air_pressure_extended_up_by_1`: Air pressure extended up by 1
     * `real(kind=kind_phys)`: units = Pa
 * `largest_model_top_pressure_that_allows_molecular_diffusion`: Largest model top pressure that allows molecular diffusion
     * `real(kind=kind_phys)`: units = Pa

--- a/StandardNamesRules.rst
+++ b/StandardNamesRules.rst
@@ -156,6 +156,7 @@ Suffixes
 | **at_pressure_levels**
 | **at_top_of_viscous_sublayer**
 | **at_various_atmosphere_layers**
+| **including_point_above_model_top**
 
 
 Component

--- a/StandardNamesRules.rst
+++ b/StandardNamesRules.rst
@@ -156,7 +156,7 @@ Suffixes
 | **at_pressure_levels**
 | **at_top_of_viscous_sublayer**
 | **at_various_atmosphere_layers**
-| **including_point_above_model_top**
+| **extended_up_by_1**
 
 
 Component

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -246,6 +246,9 @@
     <standard_name name="ln_air_pressure_of_dry_air_at_interface">
       <type kind="kind_phys" units="1">real</type>
     </standard_name>
+    <standard_name name="air_pressure_including_point_above_model_top">
+      <type kind="kind_phys" units="Pa">real</type>
+    </standard_name>
     <standard_name name="largest_model_top_pressure_that_allows_molecular_diffusion">
       <type kind="kind_phys" units="Pa">real</type>
     </standard_name>

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -40,6 +40,10 @@
                    long_name="number of vertical layers">
       <type units="count">integer</type>
     </standard_name>
+    <standard_name name="vertical_layer_dimension_extended_up_by_1"
+                   long_name="number of vertical layers extended up by 1">
+      <type units="count">integer</type>
+    </standard_name>
     <standard_name name="vertical_interface_dimension"
                    long_name="number of vertical interfaces">
       <type units="count">integer</type>
@@ -246,7 +250,7 @@
     <standard_name name="ln_air_pressure_of_dry_air_at_interface">
       <type kind="kind_phys" units="1">real</type>
     </standard_name>
-    <standard_name name="air_pressure_including_point_above_model_top">
+    <standard_name name="air_pressure_extended_up_by_1">
       <type kind="kind_phys" units="Pa">real</type>
     </standard_name>
     <standard_name name="largest_model_top_pressure_that_allows_molecular_diffusion">


### PR DESCRIPTION
### Description

~~In issue https://github.com/ESCOMP/CCPPStandardNames/issues/50, the requirement to have a suffix that indicates an additional point above the model top was outlined. This PR adds the suggested suffix to the rules document and adds the `air_pressure_including_point_above_model_top` variable that uses it to the standard_names.~~

~~Im adding this as a draft PR initially for feedback on the suitability of adding such a suffix.~~

**_Updated with feedback from_** #50.  The requirement to have a suffix that indicates an additional point above the model top was outlined and discussed. This PR adds the suggested suffix (`extended_up_by_1`) to the rules document and adds the `air_pressure_extended_up_by_1` variable and `vertical_layer_dimension_extended_up_by_1` dimension to the standard_names.

### Issue addressed

https://github.com/ESCOMP/CCPPStandardNames/issues/50