### PR TITLE
Add function to apply conversion rules to generated markdown links

### DIFF
--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -6,18 +6,18 @@
 * [state_variables](#state_variables)
 * [diagnostics](#diagnostics)
 * [atmospheric_composition](#atmospheric_composition)
-* [atmospheric_composition: GOCART aerosols](#atmospheric_composition: GOCART aerosols)
+* [atmospheric_composition: GOCART aerosols](#atmospheric_composition-gocart-aerosols)
 * [standard_variables](#standard_variables)
-* [GFS_typedefs_GFS_control_type](#GFS_typedefs_GFS_control_type)
-* [GFS_typedefs_GFS_interstitial_type](#GFS_typedefs_GFS_interstitial_type)
-* [GFS_typedefs_GFS_tbd_type](#GFS_typedefs_GFS_tbd_type)
-* [GFS_typedefs_GFS_sfcprop_type](#GFS_typedefs_GFS_sfcprop_type)
-* [GFS_typedefs_GFS_coupling_type](#GFS_typedefs_GFS_coupling_type)
-* [GFS_typedefs_GFS_statein_type](#GFS_typedefs_GFS_statein_type)
-* [GFS_typedefs_GFS_cldprop_type](#GFS_typedefs_GFS_cldprop_type)
-* [GFS_typedefs_GFS_radtend_type](#GFS_typedefs_GFS_radtend_type)
-* [GFS_typedefs_GFS_grid_type](#GFS_typedefs_GFS_grid_type)
-* [GFS_typedefs_GFS_stateout_type](#GFS_typedefs_GFS_stateout_type)
+* [GFS_typedefs_GFS_control_type](#gfs_typedefs_gfs_control_type)
+* [GFS_typedefs_GFS_interstitial_type](#gfs_typedefs_gfs_interstitial_type)
+* [GFS_typedefs_GFS_tbd_type](#gfs_typedefs_gfs_tbd_type)
+* [GFS_typedefs_GFS_sfcprop_type](#gfs_typedefs_gfs_sfcprop_type)
+* [GFS_typedefs_GFS_coupling_type](#gfs_typedefs_gfs_coupling_type)
+* [GFS_typedefs_GFS_statein_type](#gfs_typedefs_gfs_statein_type)
+* [GFS_typedefs_GFS_cldprop_type](#gfs_typedefs_gfs_cldprop_type)
+* [GFS_typedefs_GFS_radtend_type](#gfs_typedefs_gfs_radtend_type)
+* [GFS_typedefs_GFS_grid_type](#gfs_typedefs_gfs_grid_type)
+* [GFS_typedefs_GFS_stateout_type](#gfs_typedefs_gfs_stateout_type)
 
 ## dimensions
 Dimension standard names may come in sets of six related standard names for each dimension:
@@ -1236,6 +1236,8 @@ Standard / required CCPP variables
     * `integer(kind=)`: units = mm
 * `index_of_water_vegetation_category`: Index of water vegetation category
     * `integer(kind=)`: units = index
+* `filename_of_micm_configuration`: Filename of micm configuration
+    * `character(kind=len=*)`: units = none
 ## GFS_typedefs_GFS_interstitial_type
 * `cloud_ice_mixing_ratio_wrt_moist_air_interstitial`: Cloud ice mixing ratio wrt moist air interstitial
     * `real(kind=kind_phys)`: units = kg kg-1

--- a/tools/write_standard_name_table.py
+++ b/tools/write_standard_name_table.py
@@ -26,8 +26,38 @@ from xml_tools import validate_xml_file, read_xml_file
 from xml_tools import find_schema_file, find_schema_version
 
 #######################################
+#Regular expressions
+#######################################
 
 _REAL_SUBST_RE = re.compile(r"(.*\d)p(\d.*)")
+
+_DROPPED_LINK_CHARS_RE = re.compile(r"[^a-z_-]")
+
+########################################################################
+def convert_text_to_link(text_str):
+
+    """
+    When Markdown converts a header string into
+    an internal document link it applies certain
+    text conversion rules.  This function thus
+    applies those same rules to a given string
+    in order to produce the correct link.
+    """
+
+    #First trim the string to remove leading/trailing white space:
+    link_str = text_str.strip()
+
+    #Next, make sure all text is lowercase:
+    link_str = link_str.lower() #all text is lowercase
+
+    #Then, replace all spaces with dashes:
+    link_str = link_str.replace(" ", "-")
+
+    #Finally, remove all characters that aren't
+    #letters, underscores, or dashes:
+    link_str = _DROPPED_LINK_CHARS_RE.sub("",link_str)
+
+    return link_str
 
 ########################################################################
 def standard_name_to_long_name(prop_dict, context=None):
@@ -103,7 +133,8 @@ def convert_xml_to_markdown(root, library_name, snl):
     snl.write('#### Table of Contents\n')
     for section in root:
         sec_name = section.get('name')
-        snl.write("* [{name}](#{name})\n".format(name=sec_name))
+        sec_name_link = convert_text_to_link(sec_name) #convert string to link text
+        snl.write(f"* [{sec_name}](#{sec_name_link})\n")
     # end for
     snl.write('\n')
     for section in root:

--- a/tools/write_standard_name_table.py
+++ b/tools/write_standard_name_table.py
@@ -48,7 +48,7 @@ def convert_text_to_link(text_str):
     link_str = text_str.strip()
 
     #Next, make sure all text is lowercase:
-    link_str = link_str.lower() #all text is lowercase
+    link_str = link_str.lower()
 
     #Then, replace all spaces with dashes:
     link_str = link_str.replace(" ", "-")


### PR DESCRIPTION
This PR adds a function to apply header text conversion rules when generating internal markdown document links.

Fixes #54 