### PR TITLE
Add new standard names from NCAR idealized physics schemes

### DIFF
--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -7,7 +7,9 @@
 * [diagnostics](#diagnostics)
 * [atmospheric_composition](#atmospheric_composition)
 * [atmospheric_composition: GOCART aerosols](#atmospheric_composition: GOCART aerosols)
-* [standard_variables](#standard_variables)
+* [required standard variables](#required standard variables)
+* [optional standard variables](#optional standard variables)
+* [system variables](#system variables)
 * [GFS_typedefs_GFS_control_type](#GFS_typedefs_GFS_control_type)
 * [GFS_typedefs_GFS_interstitial_type](#GFS_typedefs_GFS_interstitial_type)
 * [GFS_typedefs_GFS_tbd_type](#GFS_typedefs_GFS_tbd_type)
@@ -130,6 +132,8 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `logical(kind=)`: units = flag
 * `lagrangian_tendency_of_air_pressure`: Vertical pressure velocity
     * `real(kind=kind_phys)`: units = Pa s-1
+* `density_of_dry_air`: Density of dry air
+    * `real(kind=kind_phys)`: units = kg m-3
 * `air_pressure`: Midpoint air pressure
     * `real(kind=kind_phys)`: units = Pa
 * `air_pressure_of_dry_air`: Dry midpoint pressure
@@ -152,6 +156,8 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = m
 * `geopotential_height_wrt_surface`: geopotential height w.r.t. local surface
     * `real(kind=kind_phys)`: units = m
+* `geopotential_height_wrt_surface_at_interface`: geopotential height w.r.t. local surface at interface
+    * `real(kind=kind_phys)`: units = m
 * `potentially_advected_quantities`: Potentially advected quantities
     * `real(kind=kind_phys)`: units = various
 * `air_pressure_at_interface`: Air pressure at interface
@@ -168,6 +174,8 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `logical(kind=kind_phys)`: units = flag
 * `is_initialized_physics_grid`: Flag to indicate if physics grid is initialized
     * `logical(kind=kind_phys)`: units = flag
+* `print_qneg_warn`: Logging setting for negative constituent mass fixer
+    * `character(kind=len=*)`: units = 1
 * `geopotential_height_at_interface`: Geopotential height at interface
     * `real(kind=kind_phys)`: units = m
 * `vertically_integrated_total_energy_of_initial_state`: Vertically integrated total energy of initial state
@@ -178,9 +186,11 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = kg m-2
 * `vertically_integrated_total_water_of_current_state`: Vertically integrated total water of current state
     * `real(kind=kind_phys)`: units = kg m-2
+* `heating_rate`: heating rate
+    * `real(kind=kind_phys)`: units = J kg-1 s-1
 * `tendency_of_air_temperature`: Change in temperature from a parameterization
     * `real(kind=kind_phys)`: units = K s-1
-* `tendency_of_air_temperature_due_to_model_physics`: Total change in temperature from a                               physics suite
+* `tendency_of_air_temperature_due_to_model_physics`: Total change in temperature from a physics suite
     * `real(kind=kind_phys)`: units = K s-1
 * `tendency_of_air_potential_temperature`: Change in potential temperature from a parameterization
     * `real(kind=kind_phys)`: units = K s-1
@@ -193,6 +203,14 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
 * `tendency_of_y_wind`: Change in y wind from a parameterization
     * `real(kind=kind_phys)`: units = m s-2
 * `tendency_of_y_wind_due_to_model_physics`: Tendency of y wind due to model physics
+    * `real(kind=kind_phys)`: units = m s-2
+* `tendency_of_eastward_wind`: Change in eastward wind from a parameterization
+    * `real(kind=kind_phys)`: units = m s-2
+* `tendency_of_eastward_wind_due_to_model_physics`: Total change in eastward wind from a physics suite
+    * `real(kind=kind_phys)`: units = m s-2
+* `tendency_of_northward_wind`: Change in northward wind from a parameterization
+    * `real(kind=kind_phys)`: units = m s-2
+* `tendency_of_northward_wind_due_to_model_physics`: Total change in northward wind from a physics suite
     * `real(kind=kind_phys)`: units = m s-2
 * `surface_upward_heat_flux_in_air`: Surface upward heat flux in air
     * `real(kind=kind_phys)`: units = W m-2
@@ -208,6 +226,8 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = Pa
 * `reference_air_pressure_normalized_by_surface_air_pressure`: reference pressure normalized by surface pressure
     * `real(kind=kind_phys)`: units = 1
+* `reference_pressure_in_atmosphere_layer_normalized_by_reference_pressure`: reference pressure in atmosphere layer normalized by reference pressure
+    * `real(kind=kind_phys)`: units = 1
 * `dimensionless_exner_function`: exner function
     * `real(kind=kind_phys)`: units = 1
 * `air_potential_temperature`: air potential temperature
@@ -218,6 +238,10 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = K
 * `composition_dependent_gas_constant_of_dry_air`: Composition dependent gas constant of dry air
     * `real(kind=kind_phys)`: units = J kg-1 K-1
+* `composition_dependent_specific_heat_of_dry_air_at_constant_pressure`: composition dependent specific heat of dry air at constant pressure
+    * `real(kind=kind_phys)`: units = J kg-1 K-1
+* `composition_dependent_ratio_of_dry_air_gas_constant_to_specific_heat_of_dry_air_at_constant_pressure`: composition dependent ratio of dry air gas constant to specific heat of dry air at constant pressure
+    * `real(kind=kind_phys)`: units = 1
 * `ratio_of_water_vapor_gas_constant_to_composition_dependent_dry_air_gas_constant_minus_one`: (Rwv / Rdair) - 1.0
     * `real(kind=kind_phys)`: units = 1
 * `mass_content_of_cloud_ice_in_atmosphere_layer`: Mass content of cloud ice in atmosphere layer
@@ -246,13 +270,19 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = mol mol-1
 * `water_vapor_mixing_ratio_wrt_dry_air`: Ratio of the mass of water vapor to the mass of dry air
     * `real(kind=kind_phys)`: units = kg kg-1
+* `cloud_liquid_water_mixing_ratio_wrt_moist_air_and_condensed_water`: Ratio of the mass of liquid water to the mass of moist air and condensed water
+    * `real(kind=kind_phys)`: units = kg kg-1
 * `cloud_liquid_water_mixing_ratio_wrt_moist_air`: Ratio of the mass of liquid water to the mass of moist air
     * `real(kind=kind_phys)`: units = kg kg-1
 * `cloud_liquid_water_mixing_ratio_wrt_dry_air`: Ratio of the mass of liquid water to the mass of dry air
     * `real(kind=kind_phys)`: units = kg kg-1
 * `cloud_ice_mixing_ratio_wrt_dry_air`: Ratio of the mass of ice to the mass of dry air
     * `real(kind=kind_phys)`: units = kg kg-1
+* `rain_mixing_ratio_wrt_moist_air_and_condensed_water`: ratio of the mass of rain to the mass of moist air and condensed water
+    * `real(kind=kind_phys)`: units = kg kg-1
 * `rain_mixing_ratio_wrt_moist_air`: ratio of the mass of rain to the mass of moist air
+    * `real(kind=kind_phys)`: units = kg kg-1
+* `rain_mixing_ratio_wrt_dry_air`: ratio of the mass of rain to the mass of dry air
     * `real(kind=kind_phys)`: units = kg kg-1
 * `mole_fraction_of_ozone_in_air`: Mole fraction of ozone in air
     * `real(kind=kind_phys)`: units = mol mol-1
@@ -333,11 +363,29 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = m-1
 * `volume_extinction_in_air_due_to_aerosol_particles_lambda3`: Aerosol extinction at wavelength3
     * `real(kind=kind_phys)`: units = m-1
-## standard_variables
+## required standard variables
 Standard / required CCPP variables
 * `ccpp_error_message`: Error message for error handling in CCPP
     * `character(kind=len=512)`: units = none
 * `ccpp_error_code`: Error code for error handling in CCPP
+    * `integer(kind=)`: units = 1
+## optional standard variables
+Optional CCPP variables
+* `scheme_name`: CCPP physics scheme name
+    * `character(kind=len=64)`: units = none
+* `ccpp_constituent_properties`: CCPP Constituent Properties
+    * `ccpp_constituent_prop_ptr_t(kind=)`: units = none
+* `ccpp_constituents`: Array of constituents managed by CCPP Framework
+    * `real(kind=kind_phys)`: units = none
+* `ccpp_constituent_minimum_values`: CCPP constituent minimum values
+    * `real(kind=kind_phys)`: units = none
+* `number_of_ccpp_constituents`: Number of constituents managed by CCPP Framework
+    * `integer(kind=)`: units = count
+## system variables
+Variables related to the compute environment
+* `flag_for_mpi_root`: Flag for MPI root
+    * `logical(kind=)`: units = flag
+* `log_output_unit`: Log output unit
     * `integer(kind=)`: units = 1
 ## GFS_typedefs_GFS_control_type
 * `sigma_pressure_hybrid_coordinate_a_coefficient`: Sigma pressure hybrid coordinate a coefficient

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -190,7 +190,7 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = kg m-2
 * `vertically_integrated_total_water_of_current_state`: Vertically integrated total water of current state
     * `real(kind=kind_phys)`: units = kg m-2
-* `heating_rate`: heating rate
+* `tendency_of_dry_air_enthalpy_at_constant_pressure`: Tendency of dry air enthalpy at constant pressure
     * `real(kind=kind_phys)`: units = J kg-1 s-1
 * `tendency_of_air_temperature`: Change in temperature from a parameterization
     * `real(kind=kind_phys)`: units = K s-1
@@ -224,13 +224,13 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = W m-2
 * `us_standard_air_pressure_at_sea_level`: US Standard Atmospheric pressure at sea level
     * `real(kind=kind_phys)`: units = Pa
-* `reference_pressure`: reference pressure used in definition of potential temperature, Exner function, etc.
+* `surface_reference_pressure`: Reference pressure used in definition of potential temperature, Exner function, etc.
     * `real(kind=kind_phys)`: units = Pa
 * `reference_pressure_in_atmosphere_layer`: reference pressure in atmosphere layer
     * `real(kind=kind_phys)`: units = Pa
 * `reference_air_pressure_normalized_by_surface_air_pressure`: reference pressure normalized by surface pressure
     * `real(kind=kind_phys)`: units = 1
-* `reference_pressure_in_atmosphere_layer_normalized_by_reference_pressure`: reference pressure in atmosphere layer normalized by reference pressure
+* `reference_pressure_in_atmosphere_layer_normalized_by_surface_reference_pressure`: Reference pressure in atmosphere layer normalized by surface reference pressure
     * `real(kind=kind_phys)`: units = 1
 * `dimensionless_exner_function`: exner function
     * `real(kind=kind_phys)`: units = 1

--- a/StandardNamesRules.rst
+++ b/StandardNamesRules.rst
@@ -107,6 +107,10 @@ CCPP Standard Name Rules
    use flag_for ``_X``. If it is any other data type, use control_for ``_X``. All flags
    should be Fortran logicals.
 
+#. Standard names that start with ``ccpp_`` represent CCPP framework-provided variables.
+   All other standard names should avoid the use of ``ccpp`` in their name in order
+   to avoid any confusion.
+
 #. No punctuation should appear in standard names except for underscores (_).
 
 #. Standard names are case insensitive, i.e. example = EXAMPLE.

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -193,7 +193,7 @@
                    long_name="Vertical pressure velocity">
       <type kind="kind_phys" units="Pa s-1">real</type>
     </standard_name>
-    <standard_name name="density_of_dry_air"
+    <standard_name name="dry_air_density"
                    long_name="Density of dry air">
       <type kind="kind_phys" units="kg m-3">real</type>
     </standard_name>
@@ -264,7 +264,7 @@
               long_name="Flag to indicate if physics grid is initialized">
       <type kind="kind_phys" units="flag">logical</type>
     </standard_name>
-    <standard_name name="print_qneg_warn"
+    <standard_name name="control_for_negative_constituent_warning"
               long_name="Logging setting for negative constituent mass fixer">
       <type kind="len=*" units="1">character</type>
     </standard_name>
@@ -292,7 +292,7 @@
       <type kind="kind_phys" units="K s-1">real</type>
     </standard_name>
     <standard_name name="tendency_of_air_temperature_due_to_model_physics"
-                   long_name="Total change in temperature from a physics suite">
+                   long_name="Total change in air temperature from a physics suite">
       <type kind="kind_phys" units="K s-1">real</type>
     </standard_name>
     <standard_name name="tendency_of_air_potential_temperature"
@@ -623,8 +623,8 @@
       <type kind="kind_phys" units="m-1">real</type>
     </standard_name>
   </section>
-  <section name="required standard variables"
-           comment="Standard / required CCPP variables">
+  <section name="required framework-provided variables"
+           comment="Required CCPP framework-provided variables">
     <standard_name name="ccpp_error_message"
                    long_name="Error message for error handling in CCPP">
       <type kind="len=512" units="none">character</type>
@@ -634,8 +634,8 @@
       <type kind="" units="1">integer</type>
     </standard_name>
   </section>
-  <section name="optional standard variables"
-           comment="Optional CCPP variables">
+  <section name="optional framework-provided variables"
+           comment="Optional CCPP framework-provided variables">
     <standard_name name="scheme_name"
                    long_name="CCPP physics scheme name">
       <type kind="len=64" units="none">character</type>

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -290,8 +290,8 @@
     <standard_name name="vertically_integrated_total_water_of_current_state">
       <type kind="kind_phys" units="kg m-2">real</type>
     </standard_name>
-    <standard_name name="heating_rate"
-                   long_name="heating rate">
+    <standard_name name="tendency_of_dry_air_enthalpy_at_constant_pressure"
+                   long_name="Tendency of dry air enthalpy at constant pressure">
       <type kind="kind_phys" units="J kg-1 s-1">real</type>
     </standard_name>
     <standard_name name="tendency_of_air_temperature"
@@ -352,8 +352,8 @@
                    long_name="US Standard Atmospheric pressure at sea level">
       <type kind="kind_phys" units="Pa">real</type>
     </standard_name>
-    <standard_name name="reference_pressure"
-                   long_name="reference pressure used in definition of potential temperature, Exner function, etc.">
+    <standard_name name="surface_reference_pressure"
+                   long_name="Reference pressure used in definition of potential temperature, Exner function, etc.">
       <type kind="kind_phys" units="Pa">real</type>
     </standard_name>
     <standard_name name="reference_pressure_in_atmosphere_layer"
@@ -364,8 +364,8 @@
                    long_name="reference pressure normalized by surface pressure">
       <type kind="kind_phys" units="1">real</type>
     </standard_name>
-    <standard_name name="reference_pressure_in_atmosphere_layer_normalized_by_reference_pressure"
-                   long_name="reference pressure in atmosphere layer normalized by reference pressure">
+    <standard_name name="reference_pressure_in_atmosphere_layer_normalized_by_surface_reference_pressure"
+                   long_name="Reference pressure in atmosphere layer normalized by surface reference pressure">
       <type kind="kind_phys" units="1">real</type>
     </standard_name>
     <standard_name name="dimensionless_exner_function"

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -193,6 +193,10 @@
                    long_name="Vertical pressure velocity">
       <type kind="kind_phys" units="Pa s-1">real</type>
     </standard_name>
+    <standard_name name="density_of_dry_air"
+                   long_name="Density of dry air">
+      <type kind="kind_phys" units="kg m-3">real</type>
+    </standard_name>
     <standard_name name="air_pressure"
                    long_name="Midpoint air pressure">
       <type kind="kind_phys" units="Pa">real</type>
@@ -231,6 +235,10 @@
                    long_name="geopotential height w.r.t. local surface">
       <type kind="kind_phys" units="m">real</type>
     </standard_name>
+    <standard_name name="geopotential_height_wrt_surface_at_interface"
+                   long_name="geopotential height w.r.t. local surface at interface">
+      <type kind="kind_phys" units="m">real</type>
+    </standard_name>
     <standard_name name="potentially_advected_quantities">
       <type kind="kind_phys" units="various">real</type>
     </standard_name>
@@ -256,6 +264,10 @@
               long_name="Flag to indicate if physics grid is initialized">
       <type kind="kind_phys" units="flag">logical</type>
     </standard_name>
+    <standard_name name="print_qneg_warn"
+              long_name="Logging setting for negative constituent mass fixer">
+      <type kind="len=*" units="1">character</type>
+    </standard_name>
     <standard_name name="geopotential_height_at_interface">
       <type kind="kind_phys" units="m">real</type>
     </standard_name>
@@ -271,13 +283,16 @@
     <standard_name name="vertically_integrated_total_water_of_current_state">
       <type kind="kind_phys" units="kg m-2">real</type>
     </standard_name>
+    <standard_name name="heating_rate"
+                   long_name="heating rate">
+      <type kind="kind_phys" units="J kg-1 s-1">real</type>
+    </standard_name>
     <standard_name name="tendency_of_air_temperature"
                    long_name="Change in temperature from a parameterization">
       <type kind="kind_phys" units="K s-1">real</type>
     </standard_name>
     <standard_name name="tendency_of_air_temperature_due_to_model_physics"
-                   long_name="Total change in temperature from a
-                              physics suite">
+                   long_name="Total change in temperature from a physics suite">
       <type kind="kind_phys" units="K s-1">real</type>
     </standard_name>
     <standard_name name="tendency_of_air_potential_temperature"
@@ -299,6 +314,22 @@
       <type kind="kind_phys" units="m s-2">real</type>
     </standard_name>
     <standard_name name="tendency_of_y_wind_due_to_model_physics">
+      <type kind="kind_phys" units="m s-2">real</type>
+    </standard_name>
+    <standard_name name="tendency_of_eastward_wind"
+                   long_name="Change in eastward wind from a parameterization">
+      <type kind="kind_phys" units="m s-2">real</type>
+    </standard_name>
+    <standard_name name="tendency_of_eastward_wind_due_to_model_physics"
+                   long_name="Total change in eastward wind from a physics suite">
+      <type kind="kind_phys" units="m s-2">real</type>
+    </standard_name>
+    <standard_name name="tendency_of_northward_wind"
+                   long_name="Change in northward wind from a parameterization">
+      <type kind="kind_phys" units="m s-2">real</type>
+    </standard_name>
+    <standard_name name="tendency_of_northward_wind_due_to_model_physics"
+                   long_name="Total change in northward wind from a physics suite">
       <type kind="kind_phys" units="m s-2">real</type>
     </standard_name>
     <standard_name name="surface_upward_heat_flux_in_air">
@@ -326,6 +357,10 @@
                    long_name="reference pressure normalized by surface pressure">
       <type kind="kind_phys" units="1">real</type>
     </standard_name>
+    <standard_name name="reference_pressure_in_atmosphere_layer_normalized_by_reference_pressure"
+                   long_name="reference pressure in atmosphere layer normalized by reference pressure">
+      <type kind="kind_phys" units="1">real</type>
+    </standard_name>
     <standard_name name="dimensionless_exner_function"
                    long_name="exner function">
       <type kind="kind_phys" units="1">real</type>
@@ -344,6 +379,14 @@
     </standard_name>
     <standard_name name="composition_dependent_gas_constant_of_dry_air">
       <type kind="kind_phys" units="J kg-1 K-1">real</type>
+    </standard_name>
+    <standard_name name="composition_dependent_specific_heat_of_dry_air_at_constant_pressure"
+                   long_name="composition dependent specific heat of dry air at constant pressure">
+      <type kind="kind_phys" units="J kg-1 K-1">real</type>
+    </standard_name>
+    <standard_name name="composition_dependent_ratio_of_dry_air_gas_constant_to_specific_heat_of_dry_air_at_constant_pressure"
+                   long_name="composition dependent ratio of dry air gas constant to specific heat of dry air at constant pressure">
+      <type kind="kind_phys" units="1">real</type>
     </standard_name>
     <standard_name
         name="ratio_of_water_vapor_gas_constant_to_composition_dependent_dry_air_gas_constant_minus_one"
@@ -395,6 +438,10 @@
                    long_name="Ratio of the mass of water vapor to the mass of dry air">
       <type kind="kind_phys" units="kg kg-1">real</type>
     </standard_name>
+    <standard_name name="cloud_liquid_water_mixing_ratio_wrt_moist_air_and_condensed_water"
+                   long_name="Ratio of the mass of liquid water to the mass of moist air and condensed water">
+      <type kind="kind_phys" units="kg kg-1">real</type>
+    </standard_name>
     <standard_name name="cloud_liquid_water_mixing_ratio_wrt_moist_air"
                    long_name="Ratio of the mass of liquid water to the mass of moist air">
       <type kind="kind_phys" units="kg kg-1">real</type>
@@ -407,8 +454,16 @@
                    long_name="Ratio of the mass of ice to the mass of dry air">
       <type kind="kind_phys" units="kg kg-1">real</type>
     </standard_name>
+    <standard_name name="rain_mixing_ratio_wrt_moist_air_and_condensed_water"
+                   long_name="ratio of the mass of rain to the mass of moist air and condensed water">
+      <type kind="kind_phys" units="kg kg-1">real</type>
+    </standard_name>
     <standard_name name="rain_mixing_ratio_wrt_moist_air"
                    long_name="ratio of the mass of rain to the mass of moist air">
+      <type kind="kind_phys" units="kg kg-1">real</type>
+    </standard_name>
+    <standard_name name="rain_mixing_ratio_wrt_dry_air"
+                   long_name="ratio of the mass of rain to the mass of dry air">
       <type kind="kind_phys" units="kg kg-1">real</type>
     </standard_name>
     <standard_name name="mole_fraction_of_ozone_in_air">
@@ -568,7 +623,7 @@
       <type kind="kind_phys" units="m-1">real</type>
     </standard_name>
   </section>
-  <section name="standard_variables"
+  <section name="required standard variables"
            comment="Standard / required CCPP variables">
     <standard_name name="ccpp_error_message"
                    long_name="Error message for error handling in CCPP">
@@ -576,6 +631,40 @@
     </standard_name>
     <standard_name name="ccpp_error_code"
                    long_name="Error code for error handling in CCPP">
+      <type kind="" units="1">integer</type>
+    </standard_name>
+  </section>
+  <section name="optional standard variables"
+           comment="Optional CCPP variables">
+    <standard_name name="scheme_name"
+                   long_name="CCPP physics scheme name">
+      <type kind="len=64" units="none">character</type>
+    </standard_name>
+    <standard_name name="ccpp_constituent_properties"
+                   long_name="CCPP Constituent Properties">
+      <type kind="" units="none">ccpp_constituent_prop_ptr_t</type>
+    </standard_name>
+    <standard_name name="ccpp_constituents"
+                   long_name="Array of constituents managed by CCPP Framework">
+      <type kind="kind_phys" units="none">real</type>
+    </standard_name>
+    <standard_name name="ccpp_constituent_minimum_values"
+                   long_name="CCPP constituent minimum values">
+      <type kind="kind_phys" units="none">real</type>
+    </standard_name>
+    <standard_name name="number_of_ccpp_constituents"
+                   long_name="Number of constituents managed by CCPP Framework">
+      <type kind="" units="count">integer</type>
+    </standard_name>
+  </section>
+  <section name="system variables"
+           comment="Variables related to the compute environment">
+    <standard_name name="flag_for_mpi_root"
+                   long_name="Flag for MPI root">
+      <type kind="" units="flag">logical</type>
+    </standard_name>
+    <standard_name name="log_output_unit"
+                   long_name="Log output unit">
       <type kind="" units="1">integer</type>
     </standard_name>
   </section>

--- a/tools/meta_stdname_check.py
+++ b/tools/meta_stdname_check.py
@@ -34,6 +34,7 @@ import sys
 import os
 import os.path
 import datetime
+from collections import OrderedDict
 
 ################################################
 #Add CCPP framework (lib) modules to python path
@@ -198,8 +199,8 @@ def missing_metafile_names(metafile, stdname_set):
     #Create set of all standard names not in dictionary set:
     missing_stdname_set = meta_stdname_set.difference(stdname_set)
 
-    #Return list of missing standard names:
-    return list(missing_stdname_set)
+    #Return sorted list of missing standard names:
+    return sorted(missing_stdname_set)
 
 #+++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 #Function to find the paths to all metadata files within
@@ -297,7 +298,7 @@ _, stdname_dict_root = read_xml_file(stdname_xml)
 std_names = get_dict_stdnames(stdname_dict_root)
 
 #Create new meta file/missing names dictionary:
-meta_miss_names_dict = {}
+meta_miss_names_dict = OrderedDict()
 
 #Check if user passed in single metadata file:
 if os.path.isfile(metafile_loc):


### PR DESCRIPTION
This PR adds some new CCPP standard names that are currently being used within SIMA for NCAR idealized physics schemes.  

Along with the standard names themselves, I also added a couple extra sections for some variables that I thought wouldn't fit very nicely elsewhere.  At some point I think it would be worth discussing the organization of the standard names a little more, as there are some standard names that are listed under specific GFS DDTs but which are probably more universal than that (e.g. `mpi_rank`).  However, I don't believe this potential organizational concern needs to be resolved for this particular PR.

Finally, please note that some of the links to the new sections in the generated markdown file will be broken until PR #55 has been merged.  Thanks!



