### PR TITLE
New sub-section and standard names for land surface variables

### DIFF
--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -4,6 +4,7 @@
 * [constants](#constants)
 * [coordinates](#coordinates)
 * [state_variables](#state_variables)
+* [land_surface](#land_surface)
 * [diagnostics](#diagnostics)
 * [atmospheric_composition](#atmospheric_composition)
 * [atmospheric_composition: GOCART aerosols](#atmospheric_composition-gocart-aerosols)
@@ -258,6 +259,21 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = 1
 * `gravitational_acceleration`: Gravitational acceleration
     * `real(kind=kind_phys)`: units = m s-2
+## land_surface
+* `land_ice_area_fraction`: fraction of horizontal area of grid cell that is land ice
+    * `real(kind=kind_phys)`: units = frac
+* `mass_content_of_water_in_top_soil_layer`: content per unit area of water in top layer of soil
+    * `real(kind=kind_phys)`: units = kg m-2
+* `surface_snow_density`: Surface snow density
+    * `real(kind=kind_phys)`: units = kg m-3
+* `urban_area_fraction`: fraction of horizontal area of grid cell that is urban
+    * `real(kind=kind_phys)`: units = frac
+* `volume_fraction_of_liquid_water_in_soil_at_critical_point`: volume fraction of water in liquid phase in soil at critical point
+    * `real(kind=kind_phys)`: units = m3 m-3
+* `volume_fraction_of_liquid_water_in_soil_at_saturation`: volume fraction of water in liquid phase in soil at saturation
+    * `real(kind=kind_phys)`: units = m3 m-3
+* `volume_fraction_of_liquid_water_in_soil_at_wilting_point`: volume fraction of water in liquid phase in soil at wilting point
+    * `real(kind=kind_phys)`: units = m3 m-3
 ## diagnostics
 * `total_precipitation_rate_at_surface`: Total precipitation rate at surface
     * `real(kind=kind_phys)`: units = m s-1

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -260,13 +260,13 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
 * `gravitational_acceleration`: Gravitational acceleration
     * `real(kind=kind_phys)`: units = m s-2
 ## land_surface
-* `land_ice_area_fraction`: fraction of horizontal area of grid cell that is land ice
+* `land_ice_area_fraction_of_cell_area`: fraction of horizontal area of grid cell that is land ice
     * `real(kind=kind_phys)`: units = frac
 * `mass_content_of_water_in_top_soil_layer`: content per unit area of water in top layer of soil
     * `real(kind=kind_phys)`: units = kg m-2
 * `surface_snow_density`: Surface snow density
     * `real(kind=kind_phys)`: units = kg m-3
-* `urban_area_fraction`: fraction of horizontal area of grid cell that is urban
+* `urban_area_fraction_of_cell_area`: fraction of horizontal area of grid cell that is urban
     * `real(kind=kind_phys)`: units = frac
 * `volume_fraction_of_liquid_water_in_soil_at_critical_point`: volume fraction of water in liquid phase in soil at critical point
     * `real(kind=kind_phys)`: units = m3 m-3

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -418,6 +418,35 @@
       <type kind="kind_phys" units="m s-2">real</type>
     </standard_name>
   </section>
+  <section name="land_surface">
+    <standard_name name="land_ice_area_fraction"
+                   long_name="fraction of horizontal area of grid cell that is land ice">
+      <type kind="kind_phys" units="frac">real</type>
+    </standard_name>
+    <standard_name name="mass_content_of_water_in_top_soil_layer"
+                   long_name="content per unit area of water in top layer of soil">
+      <type kind="kind_phys" units="kg m-2">real</type>
+    </standard_name>
+    <standard_name name="surface_snow_density">
+      <type kind="kind_phys" units="kg m-3">real</type>
+    </standard_name>
+    <standard_name name="urban_area_fraction"
+                   long_name="fraction of horizontal area of grid cell that is urban">
+      <type kind="kind_phys" units="frac">real</type>
+    </standard_name>
+    <standard_name name="volume_fraction_of_liquid_water_in_soil_at_critical_point"
+                   long_name="volume fraction of water in liquid phase in soil at critical point">
+      <type kind="kind_phys" units="m3 m-3">real</type>
+    </standard_name>
+    <standard_name name="volume_fraction_of_liquid_water_in_soil_at_saturation"
+                   long_name="volume fraction of water in liquid phase in soil at saturation">
+      <type kind="kind_phys" units="m3 m-3">real</type>
+    </standard_name>
+    <standard_name name="volume_fraction_of_liquid_water_in_soil_at_wilting_point"
+                   long_name="volume fraction of water in liquid phase in soil at wilting point">
+      <type kind="kind_phys" units="m3 m-3">real</type>
+    </standard_name>
+  </section>
   <section name="diagnostics">
     <standard_name name="total_precipitation_rate_at_surface">
       <type kind="kind_phys" units="m s-1">real</type>

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -419,7 +419,7 @@
     </standard_name>
   </section>
   <section name="land_surface">
-    <standard_name name="land_ice_area_fraction"
+    <standard_name name="land_ice_area_fraction_of_cell_area"
                    long_name="fraction of horizontal area of grid cell that is land ice">
       <type kind="kind_phys" units="frac">real</type>
     </standard_name>
@@ -430,7 +430,7 @@
     <standard_name name="surface_snow_density">
       <type kind="kind_phys" units="kg m-3">real</type>
     </standard_name>
-    <standard_name name="urban_area_fraction"
+    <standard_name name="urban_area_fraction_of_cell_area"
                    long_name="fraction of horizontal area of grid cell that is urban">
       <type kind="kind_phys" units="frac">real</type>
     </standard_name>


### PR DESCRIPTION
This PR addresses Issue #59 

This PR adds some variable names to the CCPP Standard Names for land surface variables, in preparation for Met 
Office work on land surface DA with JEDI. I think it makes sense to add a new sub-section for these surface variables. I have added a subsection `land_surface`, but it could be a wider scope sub-section covering all surface (i.e. land, sea, sea-ice). Please advise :)

I have added the following land surface variable names, in alphabetical order (which would be nice to see elsewhere in the CCPP Standard Names list, for ease of reference):

1. `land_ice_area_fraction`
2. `mass_content_of_water_in_top_soil_layer`
3. `surface_snow_density`
4. `urban_area_fraction`
5. `volume_fraction_of_liquid_water_in_soil_at_critical_point`
6. `volume_fraction_of_liquid_water_in_soil_at_saturation`
7. `volume_fraction_of_liquid_water_in_soil_at_wilting_point`

I have used [CF Standard Names (cfconventions.org)](https://cfconventions.org/Data/cf-standard-names/current/build/cf-standard-name-table.html) where possible, and where nothing suitable exists I have based the proposed CCPP name on the CCPP or CF name of a related or similar variable.

Opened as a draft PR for now to allow coordination between Met Office and JCSDA before submitting for review. Comments welcome in the meantime!