### PR TITLE
Add a rule to clarify vertical stagger suffixes

### DIFF
--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -162,13 +162,13 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = m
 * `potentially_advected_quantities`: Potentially advected quantities
     * `real(kind=kind_phys)`: units = various
-* `air_pressure_at_all_interfaces`: Air pressure at all interfaces
+* `air_pressure_at_interfaces`: Air pressure at interfaces
     * `real(kind=kind_phys)`: units = Pa
-* `air_pressure_of_dry_air_at_all_interfaces`: Air pressure of dry air at all interfaces
+* `air_pressure_of_dry_air_at_interfaces`: Air pressure of dry air at interfaces
     * `real(kind=kind_phys)`: units = Pa
-* `ln_air_pressure_at_all_interfaces`: Ln air pressure at all interfaces
+* `ln_air_pressure_at_interfaces`: Ln air pressure at interfaces
     * `real(kind=kind_phys)`: units = 1
-* `ln_air_pressure_of_dry_air_at_all_interfaces`: Ln air pressure of dry air at all interfaces
+* `ln_air_pressure_of_dry_air_at_interfaces`: Ln air pressure of dry air at interfaces
     * `real(kind=kind_phys)`: units = 1
 * `air_pressure_extended_up_by_1`: Air pressure extended up by 1
     * `real(kind=kind_phys)`: units = Pa
@@ -180,7 +180,7 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `logical(kind=kind_phys)`: units = flag
 * `control_for_negative_constituent_warning`: Logging setting for negative constituent mass fixer
     * `character(kind=len=*)`: units = 1
-* `geopotential_height_at_all_interfaces`: Geopotential height at all interfaces
+* `geopotential_height_at_interfaces`: Geopotential height at interfaces
     * `real(kind=kind_phys)`: units = m
 * `vertically_integrated_total_energy_of_initial_state`: Vertically integrated total energy of initial state
     * `real(kind=kind_phys)`: units = J m-2
@@ -1955,13 +1955,13 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = 1
 * `dimensionless_exner_function_at_surface_adjacent_layer`: Dimensionless exner function at surface adjacent layer
     * `real(kind=kind_phys)`: units = 1
-* `dimensionless_exner_function_at_all_interfaces`: Dimensionless exner function at all interfaces
+* `dimensionless_exner_function_at_interfaces`: Dimensionless exner function at interfaces
     * `real(kind=kind_phys)`: units = 1
 * `dissipation_estimate_of_air_temperature_at_model_layers`: Dissipation estimate of air temperature at model layers
     * `real(kind=kind_phys)`: units = K
 * `geopotential`: Geopotential
     * `real(kind=kind_phys)`: units = m2 s-2
-* `geopotential_at_all_interfaces`: Geopotential at all interfaces
+* `geopotential_at_interfaces`: Geopotential at interfaces
     * `real(kind=kind_phys)`: units = m2 s-2
 * `graupel_mixing_ratio_wrt_moist_air`: Graupel mixing ratio wrt moist air
     * `real(kind=kind_phys)`: units = kg kg-1

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -162,13 +162,13 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = m
 * `potentially_advected_quantities`: Potentially advected quantities
     * `real(kind=kind_phys)`: units = various
-* `air_pressure_at_all_interfaces`: Air pressure at interfaces between vertical grid cells
+* `air_pressure_at_all_interfaces`: Air pressure at all interfaces
     * `real(kind=kind_phys)`: units = Pa
-* `air_pressure_of_dry_air_at_all_interfaces`: Air pressure of dry air at interfaces between vertical grid cells
+* `air_pressure_of_dry_air_at_all_interfaces`: Air pressure of dry air at all interfaces
     * `real(kind=kind_phys)`: units = Pa
-* `ln_air_pressure_at_all_interfaces`: Ln air pressure at interfaces between vertical grid cells
+* `ln_air_pressure_at_all_interfaces`: Ln air pressure at all interfaces
     * `real(kind=kind_phys)`: units = 1
-* `ln_air_pressure_of_dry_air_at_all_interfaces`: Ln air pressure of dry air at interfaces between vertical grid cells
+* `ln_air_pressure_of_dry_air_at_all_interfaces`: Ln air pressure of dry air at all interfaces
     * `real(kind=kind_phys)`: units = 1
 * `air_pressure_extended_up_by_1`: Air pressure extended up by 1
     * `real(kind=kind_phys)`: units = Pa
@@ -180,7 +180,7 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `logical(kind=kind_phys)`: units = flag
 * `control_for_negative_constituent_warning`: Logging setting for negative constituent mass fixer
     * `character(kind=len=*)`: units = 1
-* `geopotential_height_at_all_interfaces`: Geopotential height at interfaces between vertical grid cells
+* `geopotential_height_at_all_interfaces`: Geopotential height at all interfaces
     * `real(kind=kind_phys)`: units = m
 * `vertically_integrated_total_energy_of_initial_state`: Vertically integrated total energy of initial state
     * `real(kind=kind_phys)`: units = J m-2
@@ -1955,13 +1955,13 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = 1
 * `dimensionless_exner_function_at_surface_adjacent_layer`: Dimensionless exner function at surface adjacent layer
     * `real(kind=kind_phys)`: units = 1
-* `dimensionless_exner_function_at_all_interfaces`: Dimensionless exner function at interfaces between vertical grid cells
+* `dimensionless_exner_function_at_all_interfaces`: Dimensionless exner function at all interfaces
     * `real(kind=kind_phys)`: units = 1
 * `dissipation_estimate_of_air_temperature_at_model_layers`: Dissipation estimate of air temperature at model layers
     * `real(kind=kind_phys)`: units = K
 * `geopotential`: Geopotential
     * `real(kind=kind_phys)`: units = m2 s-2
-* `geopotential_at_all_interfaces`: Geopotential at interfaces between vertical grid cells
+* `geopotential_at_all_interfaces`: Geopotential at all interfaces
     * `real(kind=kind_phys)`: units = m2 s-2
 * `graupel_mixing_ratio_wrt_moist_air`: Graupel mixing ratio wrt moist air
     * `real(kind=kind_phys)`: units = kg kg-1

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -153,13 +153,13 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = m
 * `potentially_advected_quantities`: Potentially advected quantities
     * `real(kind=kind_phys)`: units = various
-* `air_pressure_at_interface`: Air pressure at interface
+* `air_pressure_at_all_interfaces`: Air pressure at interfaces between vertical grid cells
     * `real(kind=kind_phys)`: units = Pa
-* `air_pressure_of_dry_air_at_interface`: Air pressure of dry air at interface
+* `air_pressure_of_dry_air_at_all_interfaces`: Air pressure of dry air at interfaces between vertical grid cells
     * `real(kind=kind_phys)`: units = Pa
-* `ln_air_pressure_at_interface`: Ln air pressure at interface
+* `ln_air_pressure_at_all_interfaces`: Ln air pressure at interfaces between vertical grid cells
     * `real(kind=kind_phys)`: units = 1
-* `ln_air_pressure_of_dry_air_at_interface`: Ln air pressure of dry air at interface
+* `ln_air_pressure_of_dry_air_at_all_interfaces`: Ln air pressure of dry air at interfaces between vertical grid cells
     * `real(kind=kind_phys)`: units = 1
 * `largest_model_top_pressure_that_allows_molecular_diffusion`: Largest model top pressure that allows molecular diffusion
     * `real(kind=kind_phys)`: units = Pa
@@ -167,7 +167,7 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `logical(kind=kind_phys)`: units = flag
 * `is_initialized_physics_grid`: Flag to indicate if physics grid is initialized
     * `logical(kind=kind_phys)`: units = flag
-* `geopotential_height_at_interface`: Geopotential height at interface
+* `geopotential_height_at_all_interfaces`: Geopotential height at interfaces between vertical grid cells
     * `real(kind=kind_phys)`: units = m
 * `vertically_integrated_total_energy_of_initial_state`: Vertically integrated total energy of initial state
     * `real(kind=kind_phys)`: units = J m-2
@@ -1839,13 +1839,13 @@ Standard / required CCPP variables
     * `real(kind=kind_phys)`: units = 1
 * `dimensionless_exner_function_at_surface_adjacent_layer`: Dimensionless exner function at surface adjacent layer
     * `real(kind=kind_phys)`: units = 1
-* `dimensionless_exner_function_at_interface`: Dimensionless exner function at interface
+* `dimensionless_exner_function_at_all_interfaces`: Dimensionless exner function at interfaces between vertical grid cells
     * `real(kind=kind_phys)`: units = 1
 * `dissipation_estimate_of_air_temperature_at_model_layers`: Dissipation estimate of air temperature at model layers
     * `real(kind=kind_phys)`: units = K
 * `geopotential`: Geopotential
     * `real(kind=kind_phys)`: units = m2 s-2
-* `geopotential_at_interface`: Geopotential at interface
+* `geopotential_at_all_interfaces`: Geopotential at interfaces between vertical grid cells
     * `real(kind=kind_phys)`: units = m2 s-2
 * `graupel_mixing_ratio_wrt_moist_air`: Graupel mixing ratio wrt moist air
     * `real(kind=kind_phys)`: units = kg kg-1

--- a/StandardNamesRules.rst
+++ b/StandardNamesRules.rst
@@ -60,7 +60,7 @@ CCPP Standard Name Rules
    * ``[variable]``, with no location suffix, is defined at vertical-cell centers or
      as vertical-cell averages.
 
-   * ``[variable]_at_interface`` is defined at the interfaces between grid cells
+   * ``[variable]_at_all_interfaces`` is defined at the interfaces between grid cells
      vertically, including the bottom-most and top-most interfaces.
    * ``[variable]_at_top_interfaces`` is defined at the interfaces between grid cells
      vertically, including the top-most interface *but excluding the bottom-most
@@ -71,7 +71,7 @@ CCPP Standard Name Rules
      top-most interface*.
 
    This implies that if ``[variable]`` is defined on `n` points vertically,
-   ``[variable]_at_interface`` is defined on `n+1` points,
+   ``[variable]_at_all_interfaces`` is defined on `n+1` points,
    ``[variable]_at_top_interfaces`` is defined on `n` points, and
    ``[variable]_at_bottom_interfaces`` is defined on `n` points.
 
@@ -159,7 +159,7 @@ Suffixes
 | at_top_of_atmosphere_boundary_layer
 | at_top_of_atmosphere_model
 | at_top_of_dry_convection
-| **at_interface**
+| **at_all_interfaces**
 | **at_surface_adjacent_layer**
 | **at_2m**
 | **at_10m**

--- a/StandardNamesRules.rst
+++ b/StandardNamesRules.rst
@@ -60,7 +60,7 @@ CCPP Standard Name Rules
    * ``[variable]``, with no location suffix, is defined at vertical-cell centers or
      as vertical-cell averages.
 
-   * ``[variable]_at_all_interfaces`` is defined at the interfaces between grid cells
+   * ``[variable]_at_interfaces`` is defined at the interfaces between grid cells
      vertically, including the bottom-most and top-most interfaces.
    * ``[variable]_at_top_interfaces`` is defined at the interfaces between grid cells
      vertically, including the top-most interface *but excluding the bottom-most
@@ -71,7 +71,7 @@ CCPP Standard Name Rules
      top-most interface*.
 
    This implies that if ``[variable]`` is defined on `n` points vertically,
-   ``[variable]_at_all_interfaces`` is defined on `n+1` points,
+   ``[variable]_at_interfaces`` is defined on `n+1` points,
    ``[variable]_at_top_interfaces`` is defined on `n` points, and
    ``[variable]_at_bottom_interfaces`` is defined on `n` points.
 
@@ -170,7 +170,7 @@ Suffixes
 | at_top_of_atmosphere_boundary_layer
 | at_top_of_atmosphere_model
 | at_top_of_dry_convection
-| **at_all_interfaces**
+| **at_interfaces**
 | **at_surface_adjacent_layer**
 | **at_2m**
 | **at_10m**

--- a/StandardNamesRules.rst
+++ b/StandardNamesRules.rst
@@ -54,21 +54,26 @@ CCPP Standard Name Rules
 #. By default (when not specified otherwise), variables are grid means or centers
    (defined by the host). If a variable is defined at a different physical location,
    a qualifier should be used to denote this. For example, to specify the vertical
-   location of a variable with respect to vertical grid cells, the following rules
-   apply. If ``[variable]`` doesn't have a vertical location suffix and is defined
-   on `n` levels:
+   location of a variable with respect to vertical grid cells, the following variants
+   are possible:
+
+   * ``[variable]``, with no location suffix, is defined at vertical-cell centers or
+     as vertical-cell averages.
 
    * ``[variable]_at_interface`` is defined at the interfaces between grid cells
-     vertically, including the bottom-most and top-most interfaces. It is defined on
-     `n+1` levels.
-
-   * ``[variable]_at_top_interfaces`` is defined at the interfaces between grid
-     cells vertically, including the top-most interface *but excluding the
-     bottom-most interface*. It is defined on `n` levels.
+     vertically, including the bottom-most and top-most interfaces.
+   * ``[variable]_at_top_interfaces`` is defined at the interfaces between grid cells
+     vertically, including the top-most interface *but excluding the bottom-most
+     interface*.
 
    * ``[variable]_at_bottom_interfaces`` is defined at the interfaces between grid
      cells vertically, including the bottom-most interface *but excluding the
-     top-most interface*. It is defined on `n` levels.
+     top-most interface*.
+
+   This implies that if ``[variable]`` is defined on `n` points vertically,
+   ``[variable]_at_interface`` is defined on `n+1` points,
+   ``[variable]_at_top_interfaces`` is defined on `n` points, and
+   ``[variable]_at_bottom_interfaces`` is defined on `n` points.
 
 #. By default, *mixing_ratio* refers to mass mixing ratios. The long name should
    explicitly specify that it refers to the *mass* mixing ratio.

--- a/StandardNamesRules.rst
+++ b/StandardNamesRules.rst
@@ -53,9 +53,22 @@ CCPP Standard Name Rules
 
 #. By default (when not specified otherwise), variables are grid means or centers
    (defined by the host). If a variable is defined at a different physical location,
-   a qualifier should be used to denote this. For example, for variables
-   representing quantities at the interface between grid cells vertically,
-   use at_interface.
+   a qualifier should be used to denote this. For example, to specify the vertical
+   location of a variable with respect to vertical grid cells, the following rules
+   apply. If ``[variable]`` doesn't have a vertical location suffix and is defined
+   on `n` levels:
+
+   * ``[variable]_at_interface`` is defined at the interfaces between grid cells
+     vertically, including the bottom-most and top-most interfaces. It is defined on
+     `n+1` levels.
+
+   * ``[variable]_at_top_interfaces`` is defined at the interfaces between grid
+     cells vertically, including the top-most interface *but excluding the
+     bottom-most interface*. It is defined on `n` levels.
+
+   * ``[variable]_at_bottom_interfaces`` is defined at the interfaces between grid
+     cells vertically, including the bottom-most interface *but excluding the
+     top-most interface*. It is defined on `n` levels.
 
 #. By default, *mixing_ratio* refers to mass mixing ratios. The long name should
    explicitly specify that it refers to the *mass* mixing ratio.

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -246,16 +246,16 @@
     <standard_name name="potentially_advected_quantities">
       <type kind="kind_phys" units="various">real</type>
     </standard_name>
-    <standard_name name="air_pressure_at_all_interfaces">
+    <standard_name name="air_pressure_at_interfaces">
       <type kind="kind_phys" units="Pa">real</type>
     </standard_name>
-    <standard_name name="air_pressure_of_dry_air_at_all_interfaces">
+    <standard_name name="air_pressure_of_dry_air_at_interfaces">
       <type kind="kind_phys" units="Pa">real</type>
     </standard_name>
-    <standard_name name="ln_air_pressure_at_all_interfaces">
+    <standard_name name="ln_air_pressure_at_interfaces">
       <type kind="kind_phys" units="1">real</type>
     </standard_name>
-    <standard_name name="ln_air_pressure_of_dry_air_at_all_interfaces">
+    <standard_name name="ln_air_pressure_of_dry_air_at_interfaces">
       <type kind="kind_phys" units="1">real</type>
     </standard_name>
     <standard_name name="air_pressure_extended_up_by_1">
@@ -275,7 +275,7 @@
               long_name="Logging setting for negative constituent mass fixer">
       <type kind="len=*" units="1">character</type>
     </standard_name>
-    <standard_name name="geopotential_height_at_all_interfaces">
+    <standard_name name="geopotential_height_at_interfaces">
       <type kind="kind_phys" units="m">real</type>
     </standard_name>
     <standard_name name="vertically_integrated_total_energy_of_initial_state">
@@ -3025,7 +3025,7 @@
       <standard_name name="dimensionless_exner_function_at_surface_adjacent_layer">
          <type kind="kind_phys" units="1">real</type>
       </standard_name>
-      <standard_name name="dimensionless_exner_function_at_all_interfaces">
+      <standard_name name="dimensionless_exner_function_at_interfaces">
          <type kind="kind_phys" units="1">real</type>
       </standard_name>
       <standard_name name="dissipation_estimate_of_air_temperature_at_model_layers">
@@ -3034,7 +3034,7 @@
       <standard_name name="geopotential">
          <type kind="kind_phys" units="m2 s-2">real</type>
       </standard_name>
-      <standard_name name="geopotential_at_all_interfaces">
+      <standard_name name="geopotential_at_interfaces">
          <type kind="kind_phys" units="m2 s-2">real</type>
       </standard_name>
       <standard_name name="graupel_mixing_ratio_wrt_moist_air">

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -232,16 +232,16 @@
     <standard_name name="potentially_advected_quantities">
       <type kind="kind_phys" units="various">real</type>
     </standard_name>
-    <standard_name name="air_pressure_at_interface">
+    <standard_name name="air_pressure_at_all_interfaces">
       <type kind="kind_phys" units="Pa">real</type>
     </standard_name>
-    <standard_name name="air_pressure_of_dry_air_at_interface">
+    <standard_name name="air_pressure_of_dry_air_at_all_interfaces">
       <type kind="kind_phys" units="Pa">real</type>
     </standard_name>
-    <standard_name name="ln_air_pressure_at_interface">
+    <standard_name name="ln_air_pressure_at_all_interfaces">
       <type kind="kind_phys" units="1">real</type>
     </standard_name>
-    <standard_name name="ln_air_pressure_of_dry_air_at_interface">
+    <standard_name name="ln_air_pressure_of_dry_air_at_all_interfaces">
       <type kind="kind_phys" units="1">real</type>
     </standard_name>
     <standard_name name="largest_model_top_pressure_that_allows_molecular_diffusion">
@@ -254,7 +254,7 @@
               long_name="Flag to indicate if physics grid is initialized">
       <type kind="kind_phys" units="flag">logical</type>
     </standard_name>
-    <standard_name name="geopotential_height_at_interface">
+    <standard_name name="geopotential_height_at_all_interfaces">
       <type kind="kind_phys" units="m">real</type>
     </standard_name>
     <standard_name name="vertically_integrated_total_energy_of_initial_state">
@@ -2799,7 +2799,7 @@
       <standard_name name="dimensionless_exner_function_at_surface_adjacent_layer">
          <type kind="kind_phys" units="1">real</type>
       </standard_name>
-      <standard_name name="dimensionless_exner_function_at_interface">
+      <standard_name name="dimensionless_exner_function_at_all_interfaces">
          <type kind="kind_phys" units="1">real</type>
       </standard_name>
       <standard_name name="dissipation_estimate_of_air_temperature_at_model_layers">
@@ -2808,7 +2808,7 @@
       <standard_name name="geopotential">
          <type kind="kind_phys" units="m2 s-2">real</type>
       </standard_name>
-      <standard_name name="geopotential_at_interface">
+      <standard_name name="geopotential_at_all_interfaces">
          <type kind="kind_phys" units="m2 s-2">real</type>
       </standard_name>
       <standard_name name="graupel_mixing_ratio_wrt_moist_air">


### PR DESCRIPTION
This PR solves issue #61 on clarifying the use of the `_at_interface` suffix. I expanded rule number 4, which describes the use of location suffixes:

> By default (when not specified otherwise), variables are grid means or centers (defined by the host). If a variable is defined at a different physical location, a qualifier should be used to denote this. For example, to specify the vertical location of a variable with respect to vertical grid cells, the following rules apply. If ``[variable]`` doesn't have a vertical location suffix and is defined on `n` levels:
>
>   * ``[variable]_at_interface`` is defined at the interfaces between grid cells vertically, including the bottom-most and top-most interfaces. It is defined on `n+1` levels.
>   * ``[variable]_at_top_interfaces`` is defined at the interfaces between grid cells vertically, including the top-most interface *but excluding the bottom-most interface*. It is defined on `n` levels.
>   * ``[variable]_at_bottom_interfaces`` is defined at the interfaces between grid cells vertically, including the bottom-most interface *but excluding the top-most interface*. It is defined on `n` levels.

I could have added an `_at_inner_interfaces` suffix for completeness. I haven't as no one has expressed a need for this suffix yet. 