### PR TITLE
Add water variables

### DIFF
--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -253,6 +253,14 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = kg m-2
 * `mass_content_of_cloud_liquid_water_in_atmosphere_layer`: Mass content of cloud liquid water in atmosphere layer
     * `real(kind=kind_phys)`: units = kg m-2
+* `mass_content_of_rain_in_atmosphere_layer`: Mass content of rain in atmosphere layer
+    * `real(kind=kind_phys)`: units = kg m-2
+* `mass_content_of_snow_in_atmosphere_layer`: Mass content of snow in atmosphere layer
+    * `real(kind=kind_phys)`: units = kg m-2
+* `mass_content_of_graupel_in_atmosphere_layer`: Mass content of graupel in atmosphere layer
+    * `real(kind=kind_phys)`: units = kg m-2
+* `mass_content_of_hail_in_atmosphere_layer`: Mass content of hail in atmosphere layer
+    * `real(kind=kind_phys)`: units = kg m-2
 * `nonconvective_cloud_area_fraction_in_atmosphere_layer`: cloud area fraction in atmosphere layer excluding clouds produced by the convective schemes
     * `real(kind=kind_phys)`: units = fraction
 * `relative_humidity`: Relative humidity
@@ -286,24 +294,58 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = kg kg-1
 * `water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water`: Ratio of the mass of water vapor to the mass of moist air and hydrometeors
     * `real(kind=kind_phys)`: units = kg kg-1
+* `water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water_at_top_interfaces`: Ratio of the mass of water vapor to the mass of moist air and hydrometeors at all interfaces excluding surface
+    * `real(kind=kind_phys)`: units = kg kg-1
 * `mole_fraction_of_water_vapor`: Mole fraction of water vapor
     * `real(kind=kind_phys)`: units = mol mol-1
 * `water_vapor_mixing_ratio_wrt_dry_air`: Ratio of the mass of water vapor to the mass of dry air
     * `real(kind=kind_phys)`: units = kg kg-1
+* `water_vapor_mixing_ratio_wrt_dry_air_at_top_interfaces`: Ratio of the mass of water vapor to the mass of dry air at all interfaces excluding surface
+    * `real(kind=kind_phys)`: units = kg kg-1
 * `cloud_liquid_water_mixing_ratio_wrt_moist_air_and_condensed_water`: Ratio of the mass of liquid water to the mass of moist air and condensed water
+    * `real(kind=kind_phys)`: units = kg kg-1
+* `cloud_liquid_water_mixing_ratio_wrt_moist_air_and_condensed_water_at_top_interfaces`: Ratio of the mass of liquid water to the mass of moist air and condensed water at all interfaces excluding surface
     * `real(kind=kind_phys)`: units = kg kg-1
 * `cloud_liquid_water_mixing_ratio_wrt_moist_air`: Ratio of the mass of liquid water to the mass of moist air
     * `real(kind=kind_phys)`: units = kg kg-1
 * `cloud_liquid_water_mixing_ratio_wrt_dry_air`: Ratio of the mass of liquid water to the mass of dry air
     * `real(kind=kind_phys)`: units = kg kg-1
+* `cloud_liquid_water_mixing_ratio_wrt_dry_air_at_top_interfaces`: Ratio of the mass of liquid water to the mass of dry air at all interfaces excluding surface
+    * `real(kind=kind_phys)`: units = kg kg-1
+* `cloud_ice_mixing_ratio_wrt_moist_air_and_condensed_water`: Ratio of the mass of ice to the mass of moist air and condensed water
+    * `real(kind=kind_phys)`: units = kg kg-1
+* `cloud_ice_mixing_ratio_wrt_moist_air_and_condensed_water_at_top_interfaces`: Ratio of the mass of ice to the mass of moist air and condensed water
+    * `real(kind=kind_phys)`: units = kg kg-1
 * `cloud_ice_mixing_ratio_wrt_dry_air`: Ratio of the mass of ice to the mass of dry air
     * `real(kind=kind_phys)`: units = kg kg-1
+* `cloud_ice_mixing_ratio_wrt_dry_air_at_top_interfaces`: Ratio of the mass of ice to the mass of dry air at all interfaces excluding surface
+    * `real(kind=kind_phys)`: units = kg kg-1
 * `rain_mixing_ratio_wrt_moist_air_and_condensed_water`: ratio of the mass of rain to the mass of moist air and condensed water
+    * `real(kind=kind_phys)`: units = kg kg-1
+* `rain_mixing_ratio_wrt_moist_air_and_condensed_water_at_top_interfaces`: ratio of the mass of rain to the mass of moist air and condensed water at all interfaces excluding surface
     * `real(kind=kind_phys)`: units = kg kg-1
 * `rain_mixing_ratio_wrt_moist_air`: ratio of the mass of rain to the mass of moist air
     * `real(kind=kind_phys)`: units = kg kg-1
 * `rain_mixing_ratio_wrt_dry_air`: ratio of the mass of rain to the mass of dry air
     * `real(kind=kind_phys)`: units = kg kg-1
+* `rain_mixing_ratio_wrt_dry_air_at_top_interfaces`: ratio of the mass of rain to the mass of dry air at all interfaces excluding surface
+    * `real(kind=kind_phys)`: units = kg kg-1
+* `total_water_mixing_ratio_wrt_moist_air_and_condensed_water`: ratio of the mass of water to the mass of moist air and condensed water
+    * `real(kind=kind_phys)`: units = kg kg-1
+* `total_water_mixing_ratio_wrt_moist_air_and_condensed_water_at_top_interfaces`: ratio of the mass of water to the mass of moist air and condensed water at all interfaces excluding surface
+    * `real(kind=kind_phys)`: units = kg kg-1
+* `total_water_mixing_ratio_wrt_dry_air`: ratio of the mass of water to the mass of dry air
+    * `real(kind=kind_phys)`: units = kg kg-1
+* `total_water_mixing_ratio_wrt_dry_air_at_top_interfaces`: ratio of the mass of water to the mass of dry air at all interfaces excluding surface
+    * `real(kind=kind_phys)`: units = kg kg-1
+* `water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water_assuming_saturation`: saturated water vapor mixing ratio with respect to moist air and condensed water
+    * `real(kind=kind_phys)`: units = kg kg-1
+* `water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water_at_top_interfaces_assuming_saturation`: saturated water vapor mixing ratio with respect to moist air and condensed water at all interfaces excluding surface
+    * `real(kind=kind_phys)`: units = kg kg-1
+* `derivative_of_ln_water_vapor_partial_pressure_assuming_saturation_wrt_air_temperature`: log derivative of the water vapor partial pressure at saturation with respect to air temperature
+    * `real(kind=kind_phys)`: units = K-1
+* `derivative_of_ln_water_vapor_partial_pressure_assuming_saturation_wrt_air_temperature_at_top_interfaces`: log derivative of the water vapor partial pressure at saturation with respect to air temperature at all interfaces excluding surface
+    * `real(kind=kind_phys)`: units = K-1
 * `mole_fraction_of_ozone_in_air`: Mole fraction of ozone in air
     * `real(kind=kind_phys)`: units = mol mol-1
 * `mole_fraction_of_carbon_dioxide_in_air`: Mole fraction of carbon dioxide in air

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -314,7 +314,7 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = kg kg-1
 * `cloud_ice_mixing_ratio_wrt_moist_air_and_condensed_water`: Ratio of the mass of ice to the mass of moist air and condensed water
     * `real(kind=kind_phys)`: units = kg kg-1
-* `cloud_ice_mixing_ratio_wrt_moist_air_and_condensed_water_at_top_interfaces`: Ratio of the mass of ice to the mass of moist air and condensed water
+* `cloud_ice_mixing_ratio_wrt_moist_air_and_condensed_water_at_top_interfaces`: Ratio of the mass of ice to the mass of moist air and condensed water at all interfaces excluding surface
     * `real(kind=kind_phys)`: units = kg kg-1
 * `cloud_ice_mixing_ratio_wrt_dry_air`: Ratio of the mass of ice to the mass of dry air
     * `real(kind=kind_phys)`: units = kg kg-1

--- a/StandardNamesRules.rst
+++ b/StandardNamesRules.rst
@@ -85,6 +85,8 @@ CCPP Standard Name Rules
    be avoided as there is no consensus on whether it refers to
    *mixing_ratio_of_water_vapor_wrt_moist_air* or
    *mixing_ratio_of_water_vapor_wrt_moist_air_and_condensed_water*.
+   *total_water* can be used to designate water in every form, i.e. water
+   vapor plus condensed water.
 
 #. Volume mixing ratios should be qualified as *volume_mixing_ratio*.
 

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -519,7 +519,7 @@
       <type kind="kind_phys" units="kg kg-1">real</type>
     </standard_name>
     <standard_name name="cloud_ice_mixing_ratio_wrt_moist_air_and_condensed_water_at_top_interfaces"
-                   long_name="Ratio of the mass of ice to the mass of moist air and condensed water">
+                   long_name="Ratio of the mass of ice to the mass of moist air and condensed water at all interfaces excluding surface">
       <type kind="kind_phys" units="kg kg-1">real</type>
     </standard_name>
     <standard_name name="cloud_ice_mixing_ratio_wrt_dry_air"

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -406,6 +406,18 @@
     <standard_name name="mass_content_of_cloud_liquid_water_in_atmosphere_layer">
       <type kind="kind_phys" units="kg m-2">real</type>
     </standard_name>
+    <standard_name name="mass_content_of_rain_in_atmosphere_layer">
+      <type kind="kind_phys" units="kg m-2">real</type>
+    </standard_name>
+    <standard_name name="mass_content_of_snow_in_atmosphere_layer">
+      <type kind="kind_phys" units="kg m-2">real</type>
+    </standard_name>
+    <standard_name name="mass_content_of_graupel_in_atmosphere_layer">
+      <type kind="kind_phys" units="kg m-2">real</type>
+    </standard_name>
+    <standard_name name="mass_content_of_hail_in_atmosphere_layer">
+      <type kind="kind_phys" units="kg m-2">real</type>
+    </standard_name>
     <standard_name
         name="nonconvective_cloud_area_fraction_in_atmosphere_layer"
         long_name="cloud area fraction in atmosphere layer excluding clouds produced by the convective schemes">
@@ -467,6 +479,10 @@
                    long_name="Ratio of the mass of water vapor to the mass of moist air and hydrometeors">
       <type kind="kind_phys" units="kg kg-1">real</type>
     </standard_name>
+    <standard_name name="water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water_at_top_interfaces"
+                   long_name="Ratio of the mass of water vapor to the mass of moist air and hydrometeors at all interfaces excluding surface">
+      <type kind="kind_phys" units="kg kg-1">real</type>
+    </standard_name>
     <standard_name name="mole_fraction_of_water_vapor">
       <type kind="kind_phys" units="mol mol-1">real</type>
     </standard_name>
@@ -474,8 +490,16 @@
                    long_name="Ratio of the mass of water vapor to the mass of dry air">
       <type kind="kind_phys" units="kg kg-1">real</type>
     </standard_name>
+    <standard_name name="water_vapor_mixing_ratio_wrt_dry_air_at_top_interfaces"
+                   long_name="Ratio of the mass of water vapor to the mass of dry air at all interfaces excluding surface">
+      <type kind="kind_phys" units="kg kg-1">real</type>
+    </standard_name>
     <standard_name name="cloud_liquid_water_mixing_ratio_wrt_moist_air_and_condensed_water"
                    long_name="Ratio of the mass of liquid water to the mass of moist air and condensed water">
+      <type kind="kind_phys" units="kg kg-1">real</type>
+    </standard_name>
+    <standard_name name="cloud_liquid_water_mixing_ratio_wrt_moist_air_and_condensed_water_at_top_interfaces"
+                   long_name="Ratio of the mass of liquid water to the mass of moist air and condensed water at all interfaces excluding surface">
       <type kind="kind_phys" units="kg kg-1">real</type>
     </standard_name>
     <standard_name name="cloud_liquid_water_mixing_ratio_wrt_moist_air"
@@ -486,12 +510,32 @@
                    long_name="Ratio of the mass of liquid water to the mass of dry air">
       <type kind="kind_phys" units="kg kg-1">real</type>
     </standard_name>
+    <standard_name name="cloud_liquid_water_mixing_ratio_wrt_dry_air_at_top_interfaces"
+                   long_name="Ratio of the mass of liquid water to the mass of dry air at all interfaces excluding surface">
+      <type kind="kind_phys" units="kg kg-1">real</type>
+    </standard_name>
+    <standard_name name="cloud_ice_mixing_ratio_wrt_moist_air_and_condensed_water"
+                   long_name="Ratio of the mass of ice to the mass of moist air and condensed water">
+      <type kind="kind_phys" units="kg kg-1">real</type>
+    </standard_name>
+    <standard_name name="cloud_ice_mixing_ratio_wrt_moist_air_and_condensed_water_at_top_interfaces"
+                   long_name="Ratio of the mass of ice to the mass of moist air and condensed water">
+      <type kind="kind_phys" units="kg kg-1">real</type>
+    </standard_name>
     <standard_name name="cloud_ice_mixing_ratio_wrt_dry_air"
                    long_name="Ratio of the mass of ice to the mass of dry air">
       <type kind="kind_phys" units="kg kg-1">real</type>
     </standard_name>
+    <standard_name name="cloud_ice_mixing_ratio_wrt_dry_air_at_top_interfaces"
+                   long_name="Ratio of the mass of ice to the mass of dry air at all interfaces excluding surface">
+      <type kind="kind_phys" units="kg kg-1">real</type>
+    </standard_name>
     <standard_name name="rain_mixing_ratio_wrt_moist_air_and_condensed_water"
                    long_name="ratio of the mass of rain to the mass of moist air and condensed water">
+      <type kind="kind_phys" units="kg kg-1">real</type>
+    </standard_name>
+    <standard_name name="rain_mixing_ratio_wrt_moist_air_and_condensed_water_at_top_interfaces"
+                   long_name="ratio of the mass of rain to the mass of moist air and condensed water at all interfaces excluding surface">
       <type kind="kind_phys" units="kg kg-1">real</type>
     </standard_name>
     <standard_name name="rain_mixing_ratio_wrt_moist_air"
@@ -501,6 +545,42 @@
     <standard_name name="rain_mixing_ratio_wrt_dry_air"
                    long_name="ratio of the mass of rain to the mass of dry air">
       <type kind="kind_phys" units="kg kg-1">real</type>
+    </standard_name>
+    <standard_name name="rain_mixing_ratio_wrt_dry_air_at_top_interfaces"
+                   long_name="ratio of the mass of rain to the mass of dry air at all interfaces excluding surface">
+      <type kind="kind_phys" units="kg kg-1">real</type>
+    </standard_name>
+    <standard_name name="total_water_mixing_ratio_wrt_moist_air_and_condensed_water"
+                   long_name="ratio of the mass of water to the mass of moist air and condensed water">
+      <type kind="kind_phys" units="kg kg-1">real</type>
+    </standard_name>
+    <standard_name name="total_water_mixing_ratio_wrt_moist_air_and_condensed_water_at_top_interfaces"
+                   long_name="ratio of the mass of water to the mass of moist air and condensed water at all interfaces excluding surface">
+      <type kind="kind_phys" units="kg kg-1">real</type>
+    </standard_name>
+    <standard_name name="total_water_mixing_ratio_wrt_dry_air"
+                   long_name="ratio of the mass of water to the mass of dry air">
+      <type kind="kind_phys" units="kg kg-1">real</type>
+    </standard_name>
+    <standard_name name="total_water_mixing_ratio_wrt_dry_air_at_top_interfaces"
+                   long_name="ratio of the mass of water to the mass of dry air at all interfaces excluding surface">
+      <type kind="kind_phys" units="kg kg-1">real</type>
+    </standard_name>
+    <standard_name name="water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water_assuming_saturation"
+                   long_name="saturated water vapor mixing ratio with respect to moist air and condensed water">
+      <type kind="kind_phys" units="kg kg-1">real</type>
+    </standard_name>
+    <standard_name name="water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water_at_top_interfaces_assuming_saturation"
+                   long_name="saturated water vapor mixing ratio with respect to moist air and condensed water at all interfaces excluding surface">
+      <type kind="kind_phys" units="kg kg-1">real</type>
+    </standard_name>
+    <standard_name name="derivative_of_ln_water_vapor_partial_pressure_assuming_saturation_wrt_air_temperature"
+                   long_name="log derivative of the water vapor partial pressure at saturation with respect to air temperature">
+      <type kind="kind_phys" units="K-1">real</type>
+    </standard_name>
+    <standard_name name="derivative_of_ln_water_vapor_partial_pressure_assuming_saturation_wrt_air_temperature_at_top_interfaces"
+                   long_name="log derivative of the water vapor partial pressure at saturation with respect to air temperature at all interfaces excluding surface">
+      <type kind="kind_phys" units="K-1">real</type>
     </standard_name>
     <standard_name name="mole_fraction_of_ozone_in_air">
       <type kind="kind_phys" units="mol mol-1">real</type>


### PR DESCRIPTION
This PR extends a few variables related to atmospheric water:

- It extends the 3D mass contents to include a rain, snow, graupel and hail versions. 
- It extends the water mixing ratios of water vapor, cloud ice, cloud liquid water and rain by adding variants with the `_at_top_interfaces` vertical stagger. I only updated the mixing ratios wrt dry air and the mixing ratios wrt moist air and condensed water, as I don't need the mixing ratios wrt moist air alone.

It also adds a few water-related variables:
- Mixing ratios of total water.
- `water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water_assuming_saturation` for saturated specific humidity.
- `derivative_of_ln_water_vapor_partial_pressure_assuming_saturation_wrt_air_temperature` for the log derivative of saturation vapor pressure wrt temperature.
- The `_at_top_interaces` variants of the latter two variables. 