### PR TITLE
Add miscellaneous atmosphere variables

### DIFF
--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -129,6 +129,10 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = m s-1
 * `northward_wind`: Wind vector component, positive when directed northward
     * `real(kind=kind_phys)`: units = m s-1
+* `eastward_wind_at_10m`: Wind vector component at 10m, positive when directed eastward
+    * `real(kind=kind_phys)`: units = m s-1
+* `northward_wind_at_10m`: Wind vector component at 10m, positive when directed northward
+    * `real(kind=kind_phys)`: units = m s-1
 * `surface_wind_speed`: Scalar wind speed at surface
     * `real(kind=kind_phys)`: units = m s-1
 * `surface_wind_from_direction`: Direction, from north, of wind speed at surface

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -129,18 +129,10 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = m s-1
 * `northward_wind`: Wind vector component, positive when directed northward
     * `real(kind=kind_phys)`: units = m s-1
-* `surface_eastward_wind`: Surface wind vector component, positive when directed eastward
-    * `real(kind=kind_phys)`: units = m s-1
-* `surface_northward_wind`: Surface wind vector component, positive when directed northward
-    * `real(kind=kind_phys)`: units = m s-1
 * `eastward_wind_at_10m`: Wind vector component at 10m, positive when directed eastward
     * `real(kind=kind_phys)`: units = m s-1
 * `northward_wind_at_10m`: Wind vector component at 10m, positive when directed northward
     * `real(kind=kind_phys)`: units = m s-1
-* `surface_wind_speed`: Scalar wind speed at surface
-    * `real(kind=kind_phys)`: units = m s-1
-* `surface_wind_from_direction`: Direction, from north, of wind speed at surface
-    * `real(kind=kind_phys)`: units = degrees
 * `dry_static_energy`: Dry static energy Content of Atmosphere Layer
     * `real(kind=kind_phys)`: units = J kg-1
 * `do_lagrangian_vertical_coordinate`: flag indicating if vertical coordinate is lagrangian

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -253,6 +253,8 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = K
 * `virtual_temperature`: virtual temperature
     * `real(kind=kind_phys)`: units = K
+* `virtual_potential_temperature`: virtual potential temperature
+    * `real(kind=kind_phys)`: units = K
 * `composition_dependent_gas_constant_of_dry_air`: Composition dependent gas constant of dry air
     * `real(kind=kind_phys)`: units = J kg-1 K-1
 * `composition_dependent_specific_heat_of_dry_air_at_constant_pressure`: composition dependent specific heat of dry air at constant pressure

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -277,6 +277,8 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = fraction
 * `relative_humidity`: Relative humidity
     * `real(kind=kind_phys)`: units = fraction
+* `relative_humidity_at_2m`: Relative humidity at 2m
+    * `real(kind=kind_phys)`: units = fraction
 * `gravitational_acceleration`: Gravitational acceleration
     * `real(kind=kind_phys)`: units = m s-2
 ## land_surface

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -129,6 +129,10 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = m s-1
 * `northward_wind`: Wind vector component, positive when directed northward
     * `real(kind=kind_phys)`: units = m s-1
+* `surface_eastward_wind`: Surface wind vector component, positive when directed eastward
+    * `real(kind=kind_phys)`: units = m s-1
+* `surface_northward_wind`: Surface wind vector component, positive when directed northward
+    * `real(kind=kind_phys)`: units = m s-1
 * `eastward_wind_at_10m`: Wind vector component at 10m, positive when directed eastward
     * `real(kind=kind_phys)`: units = m s-1
 * `northward_wind_at_10m`: Wind vector component at 10m, positive when directed northward

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -129,6 +129,10 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = m s-1
 * `northward_wind`: Wind vector component, positive when directed northward
     * `real(kind=kind_phys)`: units = m s-1
+* `surface_wind_speed`: Scalar wind speed at surface
+    * `real(kind=kind_phys)`: units = m s-1
+* `surface_wind_from_direction`: Direction, from north, of wind speed at surface
+    * `real(kind=kind_phys)`: units = degrees
 * `dry_static_energy`: Dry static energy Content of Atmosphere Layer
     * `real(kind=kind_phys)`: units = J kg-1
 * `do_lagrangian_vertical_coordinate`: flag indicating if vertical coordinate is lagrangian

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -450,6 +450,9 @@
     <standard_name name="relative_humidity">
       <type kind="kind_phys" units="fraction">real</type>
     </standard_name>
+    <standard_name name="relative_humidity_at_2m">
+      <type kind="kind_phys" units="fraction">real</type>
+    </standard_name>
     <standard_name name="gravitational_acceleration">
       <type kind="kind_phys" units="m s-2">real</type>
     </standard_name>

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -408,6 +408,10 @@
                    long_name="virtual temperature">
       <type kind="kind_phys" units="K">real</type>
     </standard_name>
+    <standard_name name="virtual_potential_temperature"
+                   long_name="virtual potential temperature">
+      <type kind="kind_phys" units="K">real</type>
+    </standard_name>
     <standard_name name="composition_dependent_gas_constant_of_dry_air">
       <type kind="kind_phys" units="J kg-1 K-1">real</type>
     </standard_name>

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -185,6 +185,14 @@
                    long_name="Wind vector component, positive when directed northward">
       <type kind="kind_phys" units="m s-1">real</type>
     </standard_name>
+    <standard_name name="surface_wind_speed"
+                   long_name="Scalar wind speed at surface">
+      <type kind="kind_phys" units="m s-1">real</type>
+    </standard_name>
+    <standard_name name="surface_wind_from_direction"
+                   long_name="Direction, from north, of wind speed at surface">
+      <type kind="kind_phys" units="degrees">real</type>
+    </standard_name>
     <standard_name name="dry_static_energy"
                    long_name="Dry static energy Content of Atmosphere Layer">
       <type kind="kind_phys" units="J kg-1">real</type>

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -185,6 +185,14 @@
                    long_name="Wind vector component, positive when directed northward">
       <type kind="kind_phys" units="m s-1">real</type>
     </standard_name>
+    <standard_name name="surface_eastward_wind"
+                   long_name="Surface wind vector component, positive when directed eastward">
+      <type kind="kind_phys" units="m s-1">real</type>
+    </standard_name>
+    <standard_name name="surface_northward_wind"
+                   long_name="Surface wind vector component, positive when directed northward">
+      <type kind="kind_phys" units="m s-1">real</type>
+    </standard_name>
     <standard_name name="eastward_wind_at_10m"
                    long_name="Wind vector component at 10m, positive when directed eastward">
       <type kind="kind_phys" units="m s-1">real</type>

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -185,6 +185,14 @@
                    long_name="Wind vector component, positive when directed northward">
       <type kind="kind_phys" units="m s-1">real</type>
     </standard_name>
+    <standard_name name="eastward_wind_at_10m"
+                   long_name="Wind vector component at 10m, positive when directed eastward">
+      <type kind="kind_phys" units="m s-1">real</type>
+    </standard_name>
+    <standard_name name="northward_wind_at_10m"
+                   long_name="Wind vector component at 10m, positive when directed northward">
+      <type kind="kind_phys" units="m s-1">real</type>
+    </standard_name>
     <standard_name name="surface_wind_speed"
                    long_name="Scalar wind speed at surface">
       <type kind="kind_phys" units="m s-1">real</type>

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -185,14 +185,6 @@
                    long_name="Wind vector component, positive when directed northward">
       <type kind="kind_phys" units="m s-1">real</type>
     </standard_name>
-    <standard_name name="surface_eastward_wind"
-                   long_name="Surface wind vector component, positive when directed eastward">
-      <type kind="kind_phys" units="m s-1">real</type>
-    </standard_name>
-    <standard_name name="surface_northward_wind"
-                   long_name="Surface wind vector component, positive when directed northward">
-      <type kind="kind_phys" units="m s-1">real</type>
-    </standard_name>
     <standard_name name="eastward_wind_at_10m"
                    long_name="Wind vector component at 10m, positive when directed eastward">
       <type kind="kind_phys" units="m s-1">real</type>
@@ -200,14 +192,6 @@
     <standard_name name="northward_wind_at_10m"
                    long_name="Wind vector component at 10m, positive when directed northward">
       <type kind="kind_phys" units="m s-1">real</type>
-    </standard_name>
-    <standard_name name="surface_wind_speed"
-                   long_name="Scalar wind speed at surface">
-      <type kind="kind_phys" units="m s-1">real</type>
-    </standard_name>
-    <standard_name name="surface_wind_from_direction"
-                   long_name="Direction, from north, of wind speed at surface">
-      <type kind="kind_phys" units="degrees">real</type>
     </standard_name>
     <standard_name name="dry_static_energy"
                    long_name="Dry static energy Content of Atmosphere Layer">


### PR DESCRIPTION
This adds some new variable names, used in the JEDI system, that are mostly usual variants of existing CCPP variable names. They concern winds, temperature, and relative humidity.

~~Perhaps the newest concept introduced here is `surface_wind_from_direction`. I did not find any other existing CCPP variable names with direction expressed in degrees like this one.~~ removed from this PR