### PR TITLE
Update StandardNamesRules.rst: change`surface` prefix  to `_at_surface` suffix

### DIFF
--- a/StandardNamesRules.rst
+++ b/StandardNamesRules.rst
@@ -154,7 +154,7 @@ Prefixes
 
 None. Note that this is a departure from the CF conventions, which use
 surface_ as a prefix. This is to maintain consistency with all other
-level qualifiers that are used as _at_level-qualifier as suffix.
+level qualifiers that are used as _at_level-qualifier (i.e. as suffix).
 
 Suffixes
 ^^^^^^^^

--- a/StandardNamesRules.rst
+++ b/StandardNamesRules.rst
@@ -42,7 +42,7 @@ CCPP Standard Name Rules
    words or phrases to be substituted. The new standard name is constructed by
    joining the base standard name to the qualifiers using underscores.
 
-   [``surface``] [``component``] standard_name [*at* ``surface``] [*in* ``medium``]
+   [``component``] standard_name [*at* ``level``] [*in* ``medium``]
    [*due_to* ``process``] [*assuming* ``condition``]
 
    See the list of currently-used qualifiers below for help.
@@ -152,9 +152,9 @@ XY-surface
 Prefixes
 ^^^^^^^^
 
-| toa
-| tropopause
-| surface
+None. Note that this is a departure from the CF conventions, which use
+surface_ as a prefix. This is to maintain consistency with all other
+level qualifiers that are used as _at_level-qualifier as suffix.
 
 Suffixes
 ^^^^^^^^
@@ -173,6 +173,9 @@ Suffixes
 | at_top_of_atmosphere_model
 | at_top_of_dry_convection
 | **at_interfaces**
+| **at_toa**
+| **at_tropopause**
+| **at_surface**
 | **at_surface_adjacent_layer**
 | **at_2m**
 | **at_10m**

--- a/StandardNamesRules.rst
+++ b/StandardNamesRules.rst
@@ -24,9 +24,10 @@ CCPP Standard Name Rules
 #. Standard names should be identical to those from the latest version
    of the `Climate and Forecast (CF) metadata
    conventions <https://cfconventions.org/standard-names.html>`_ unless
-   an appropriate name does not exist in that standard.
+   an appropriate name does not exist in that standard, or the adoption
+   of said names leads to inconsistencies in the naming convention.
 
-#. When a standard name doesn’t exist in the CF conventions, follow their
+#. When no suitable standard name exists in the CF conventions, follow their
    guidelines for standard name construction at this URL:
    http://cfconventions.org/Data/cf-standard-names/docs/guidelines.html. Standard
    names may be qualified by the addition of phrases in certain standard forms and
@@ -152,9 +153,10 @@ XY-surface
 Prefixes
 ^^^^^^^^
 
-None. Note that this is a departure from the CF conventions, which use
-surface_ as a prefix. This is to maintain consistency with all other
-level qualifiers that are used as _at_level-qualifier (i.e. as suffix).
+None. Note that this is a departure from the CF conventions, which in
+many cases - but not all - use surface_ as a prefix. This departure from
+the CF convention is to maintain consistency with all other level
+qualifiers that are used as _at_level-qualifier (i.e. as suffix).
 
 Suffixes
 ^^^^^^^^


### PR DESCRIPTION
This PR changes the rules (and the rules only) to make `surface` a suffix (`at_surface`) rather than a prefix. This proposed change was discussed in last week's CCPP framework meeting and is a departure from the CF conventions, which use `surface_` as a prefix. The motivation for this change is to maintain consistency with all other level qualifiers that are used as `_at_level` qualifier (i.e. as suffix).