### PR TITLE
Add four wind CF variables

### DIFF
--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -223,7 +223,7 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = m2 s-1
 * `atmosphere_upward_absolute_vorticity`: The curl of the vector wind field
     * `real(kind=kind_phys)`: units = s-1
-* `divergence_of_wind`: The divergence of the vector wind field
+* `divergence_of_wind`: The (horizontal) divergence of the 2-D vector wind field
     * `real(kind=kind_phys)`: units = s-1
 * `surface_upward_heat_flux_in_air`: Surface upward heat flux in air
     * `real(kind=kind_phys)`: units = W m-2

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -223,7 +223,7 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = m2 s-1
 * `atmosphere_upward_absolute_vorticity`: The curl of the vector wind field
     * `real(kind=kind_phys)`: units = s-1
-* `horizontal_divergence_of_wind`: The divergence of the vector wind field
+* `divergence_of_wind`: The divergence of the vector wind field
     * `real(kind=kind_phys)`: units = s-1
 * `surface_upward_heat_flux_in_air`: Surface upward heat flux in air
     * `real(kind=kind_phys)`: units = W m-2

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -217,6 +217,14 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = m s-2
 * `tendency_of_northward_wind_due_to_model_physics`: Total change in northward wind from a physics suite
     * `real(kind=kind_phys)`: units = m s-2
+* `atmosphere_horizontal_streamfunction`: Scalar function describing the stream lines of the wind
+    * `real(kind=kind_phys)`: units = m2 s-1
+* `atmosphere_horizontal_velocity_potential`: Scalar potential of the wind
+    * `real(kind=kind_phys)`: units = m2 s-1
+* `atmosphere_upward_absolute_vorticity`: The curl of the vector wind field
+    * `real(kind=kind_phys)`: units = s-1
+* `horizontal_divergence_of_wind`: The divergence of the vector wind field
+    * `real(kind=kind_phys)`: units = s-1
 * `surface_upward_heat_flux_in_air`: Surface upward heat flux in air
     * `real(kind=kind_phys)`: units = W m-2
 * `cumulative_boundary_flux_of_total_energy`: Cumulative boundary flux of total energy

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -351,7 +351,7 @@
                    long_name="The curl of the vector wind field">
       <type kind="kind_phys" units="s-1">real</type>
     </standard_name>
-    <standard_name name="horizontal_divergence_of_wind"
+    <standard_name name="divergence_of_wind"
                    long_name="The divergence of the vector wind field">
       <type kind="kind_phys" units="s-1">real</type>
     </standard_name>

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -352,7 +352,7 @@
       <type kind="kind_phys" units="s-1">real</type>
     </standard_name>
     <standard_name name="horizontal_divergence_of_wind"
-                   long_name="The divergence of the vector wind field>
+                   long_name="The divergence of the vector wind field">
       <type kind="kind_phys" units="s-1">real</type>
     </standard_name>
     <standard_name name="surface_upward_heat_flux_in_air">

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -339,6 +339,22 @@
                    long_name="Total change in northward wind from a physics suite">
       <type kind="kind_phys" units="m s-2">real</type>
     </standard_name>
+    <standard_name name="atmosphere_horizontal_streamfunction"
+                   long_name="Scalar function describing the stream lines of the wind">
+      <type kind="kind_phys" units="m2 s-1">real</type>
+    </standard_name>
+    <standard_name name="atmosphere_horizontal_velocity_potential"
+                   long_name="Scalar potential of the wind">
+      <type kind="kind_phys" units="m2 s-1">real</type>
+    </standard_name>
+    <standard_name name="atmosphere_upward_absolute_vorticity"
+                   long_name="The curl of the vector wind field">
+      <type kind="kind_phys" units="s-1">real</type>
+    </standard_name>
+    <standard_name name="horizontal_divergence_of_wind"
+                   long_name="The divergence of the vector wind field>
+      <type kind="kind_phys" units="s-1">real</type>
+    </standard_name>
     <standard_name name="surface_upward_heat_flux_in_air">
       <type kind="kind_phys" units="W m-2">real</type>
     </standard_name>

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -352,7 +352,7 @@
       <type kind="kind_phys" units="s-1">real</type>
     </standard_name>
     <standard_name name="divergence_of_wind"
-                   long_name="The divergence of the vector wind field">
+                   long_name="The (horizontal) divergence of the 2-D vector wind field">
       <type kind="kind_phys" units="s-1">real</type>
     </standard_name>
     <standard_name name="surface_upward_heat_flux_in_air">


### PR DESCRIPTION
This adds four variables related to wind fluid dynamics. The names are already CF names that have not yet been added to the CCPP standard.