### PR TITLE
New wind variables at surface

### DIFF
--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -133,13 +133,13 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = m s-1
 * `northward_wind_at_10m`: Wind vector component at 10m, positive when directed northward
     * `real(kind=kind_phys)`: units = m s-1
-* `eastward_wind_at_surface`: Wind vector component at surface, positive when directed eastward
+* `eastward_wind_at_surface`: Wind vector component closest to surface, positive when directed eastward
     * `real(kind=kind_phys)`: units = m s-1
-* `northward_wind_at_surface`: Wind vector component at surface, positive when directed northward
+* `northward_wind_at_surface`: Wind vector component closest to surface, positive when directed northward
     * `real(kind=kind_phys)`: units = m s-1
-* `wind_speed_at_surface`: Scalar wind speed at surface
+* `wind_speed_at_surface`: Scalar wind speed closest to surface
     * `real(kind=kind_phys)`: units = m s-1
-* `wind_from_direction_at_surface`: Direction, from north, of wind speed at surface
+* `wind_from_direction_at_surface`: Direction, from north, of wind speed closest to surface
     * `real(kind=kind_phys)`: units = degrees
 * `dry_static_energy`: Dry static energy Content of Atmosphere Layer
     * `real(kind=kind_phys)`: units = J kg-1

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -133,6 +133,10 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = m s-1
 * `northward_wind_at_10m`: Wind vector component at 10m, positive when directed northward
     * `real(kind=kind_phys)`: units = m s-1
+* `wind_speed_at_surface`: Scalar wind speed at surface
+    * `real(kind=kind_phys)`: units = m s-1
+* `wind_from_direction_at_surface`: Direction, from north, of wind speed at surface
+    * `real(kind=kind_phys)`: units = degrees
 * `dry_static_energy`: Dry static energy Content of Atmosphere Layer
     * `real(kind=kind_phys)`: units = J kg-1
 * `do_lagrangian_vertical_coordinate`: flag indicating if vertical coordinate is lagrangian

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -133,6 +133,10 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = m s-1
 * `northward_wind_at_10m`: Wind vector component at 10m, positive when directed northward
     * `real(kind=kind_phys)`: units = m s-1
+* `eastward_wind_at_surface`: Wind vector component at surface, positive when directed eastward
+    * `real(kind=kind_phys)`: units = m s-1
+* `northward_wind_at_surface`: Wind vector component at surface, positive when directed northward
+    * `real(kind=kind_phys)`: units = m s-1
 * `wind_speed_at_surface`: Scalar wind speed at surface
     * `real(kind=kind_phys)`: units = m s-1
 * `wind_from_direction_at_surface`: Direction, from north, of wind speed at surface

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -192,6 +192,14 @@
     <standard_name name="northward_wind_at_10m"
                    long_name="Wind vector component at 10m, positive when directed northward">
       <type kind="kind_phys" units="m s-1">real</type>
+    <standard_name name="eastward_wind_at_surface"
+                   long_name="Wind vector component at surface, positive when directed eastward">
+      <type kind="kind_phys" units="m s-1">real</type>
+    </standard_name>
+    <standard_name name="northward_wind_at_surface"
+                   long_name="Wind vector component at surface, positive when directed northward">
+      <type kind="kind_phys" units="m s-1">real</type>
+    </standard_name>
     </standard_name>
        <standard_name name="wind_speed_at_surface"
                    long_name="Scalar wind speed at surface">

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -194,19 +194,19 @@
       <type kind="kind_phys" units="m s-1">real</type>
     </standard_name>
     <standard_name name="eastward_wind_at_surface"
-                   long_name="Wind vector component at surface, positive when directed eastward">
+                   long_name="Wind vector component closest to surface, positive when directed eastward">
       <type kind="kind_phys" units="m s-1">real</type>
     </standard_name>
     <standard_name name="northward_wind_at_surface"
-                   long_name="Wind vector component at surface, positive when directed northward">
+                   long_name="Wind vector component closest to surface, positive when directed northward">
       <type kind="kind_phys" units="m s-1">real</type>
     </standard_name>
     <standard_name name="wind_speed_at_surface"
-                   long_name="Scalar wind speed at surface">
+                   long_name="Scalar wind speed closest to surface">
       <type kind="kind_phys" units="m s-1">real</type>
     </standard_name>
     <standard_name name="wind_from_direction_at_surface"
-                   long_name="Direction, from north, of wind speed at surface">
+                   long_name="Direction, from north, of wind speed closest to surface">
       <type kind="kind_phys" units="degrees">real</type>
     </standard_name>
     <standard_name name="dry_static_energy"

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -193,6 +193,14 @@
                    long_name="Wind vector component at 10m, positive when directed northward">
       <type kind="kind_phys" units="m s-1">real</type>
     </standard_name>
+       <standard_name name="wind_speed_at_surface"
+                   long_name="Scalar wind speed at surface">
+      <type kind="kind_phys" units="m s-1">real</type>
+    </standard_name>
+    <standard_name name="wind_from_direction_at_surface"
+                   long_name="Direction, from north, of wind speed at surface">
+      <type kind="kind_phys" units="degrees">real</type>
+    </standard_name>
     <standard_name name="dry_static_energy"
                    long_name="Dry static energy Content of Atmosphere Layer">
       <type kind="kind_phys" units="J kg-1">real</type>

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -200,8 +200,7 @@
                    long_name="Wind vector component at surface, positive when directed northward">
       <type kind="kind_phys" units="m s-1">real</type>
     </standard_name>
-    </standard_name>
-       <standard_name name="wind_speed_at_surface"
+    <standard_name name="wind_speed_at_surface"
                    long_name="Scalar wind speed at surface">
       <type kind="kind_phys" units="m s-1">real</type>
     </standard_name>

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -192,6 +192,7 @@
     <standard_name name="northward_wind_at_10m"
                    long_name="Wind vector component at 10m, positive when directed northward">
       <type kind="kind_phys" units="m s-1">real</type>
+    </standard_name>
     <standard_name name="eastward_wind_at_surface"
                    long_name="Wind vector component at surface, positive when directed eastward">
       <type kind="kind_phys" units="m s-1">real</type>


### PR DESCRIPTION
This adds two pairs of wind variables for winds at the surface layer.

Note that the names here assume that the naming rule changes in #72 will be merged.