### PR TITLE
Add/modify variable names related to surface height/pressure

### DIFF
--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -111,7 +111,7 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = Pa
 * `air_pressure_at_sea_level`: Air pressure at sea level
     * `real(kind=kind_phys)`: units = Pa
-* `air_pressure_at_surface`: Air pressure at surface
+* `air_pressure_at_surface`: Air pressure at local surface
     * `real(kind=kind_phys)`: units = Pa
 * `surface_pressure_of_dry_air`: Surface pressure of dry air
     * `real(kind=kind_phys)`: units = Pa
@@ -161,7 +161,7 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = 1
 * `geopotential_height`: geopotential height w.r.t. sea level
     * `real(kind=kind_phys)`: units = m
-* `geopotential_height_at_surface`: geopotential height at local surface
+* `geopotential_height_at_surface`: Geopotential height at local surface w.r.t. sea level
     * `real(kind=kind_phys)`: units = m
 * `geopotential_height_wrt_surface`: geopotential height w.r.t. local surface
     * `real(kind=kind_phys)`: units = m
@@ -1661,7 +1661,7 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = m
 * `height_above_mean_sea_level`: Height above mean sea level
     * `real(kind=kind_phys)`: units = m
-* `height_above_mean_sea_level_at_surface`: height above mean sea level at local surface
+* `height_above_mean_sea_level_at_surface`: Height above mean sea level at local surface
     * `real(kind=kind_phys)`: units = m
 * `unfiltered_height_above_mean_sea_level`: Unfiltered height above mean sea level
     * `real(kind=kind_phys)`: units = m

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -1661,6 +1661,8 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = m
 * `height_above_mean_sea_level`: Height above mean sea level
     * `real(kind=kind_phys)`: units = m
+* `height_above_mean_sea_level_at_surface`: Height above mean sea level at local surface
+    * `real(kind=kind_phys)`: units = m
 * `unfiltered_height_above_mean_sea_level`: Unfiltered height above mean sea level
     * `real(kind=kind_phys)`: units = m
 * `air_potential_temperature_at_2m`: Air potential temperature at 2m

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -111,7 +111,7 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = Pa
 * `air_pressure_at_sea_level`: Air pressure at sea level
     * `real(kind=kind_phys)`: units = Pa
-* `air_pressure_at_surface`: Air pressure at local surface
+* `air_pressure_at_surface`: Air pressure at surface
     * `real(kind=kind_phys)`: units = Pa
 * `surface_pressure_of_dry_air`: Surface pressure of dry air
     * `real(kind=kind_phys)`: units = Pa
@@ -1661,7 +1661,7 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = m
 * `height_above_mean_sea_level`: Height above mean sea level
     * `real(kind=kind_phys)`: units = m
-* `height_above_mean_sea_level_at_surface`: Height above mean sea level at local surface
+* `height_above_mean_sea_level_at_surface`: height above mean sea level at local surface
     * `real(kind=kind_phys)`: units = m
 * `unfiltered_height_above_mean_sea_level`: Unfiltered height above mean sea level
     * `real(kind=kind_phys)`: units = m

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -161,6 +161,8 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = 1
 * `geopotential_height`: geopotential height w.r.t. sea level
     * `real(kind=kind_phys)`: units = m
+* `geopotential_height_at_surface`: geopotential height at local surface
+    * `real(kind=kind_phys)`: units = m
 * `geopotential_height_wrt_surface`: geopotential height w.r.t. local surface
     * `real(kind=kind_phys)`: units = m
 * `geopotential_height_wrt_surface_at_interface`: geopotential height w.r.t. local surface at interface

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -111,7 +111,7 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = Pa
 * `air_pressure_at_sea_level`: Air pressure at sea level
     * `real(kind=kind_phys)`: units = Pa
-* `air_pressure_at_surface`: Air pressure at surface
+* `air_pressure_at_surface`: Air pressure at local surface
     * `real(kind=kind_phys)`: units = Pa
 * `surface_pressure_of_dry_air`: Surface pressure of dry air
     * `real(kind=kind_phys)`: units = Pa

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -111,7 +111,7 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = Pa
 * `air_pressure_at_sea_level`: Air pressure at sea level
     * `real(kind=kind_phys)`: units = Pa
-* `surface_air_pressure`: Surface air pressure
+* `air_pressure_at_surface`: Air pressure at surface
     * `real(kind=kind_phys)`: units = Pa
 * `surface_pressure_of_dry_air`: Surface pressure of dry air
     * `real(kind=kind_phys)`: units = Pa

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -243,6 +243,10 @@
                    long_name="geopotential height w.r.t. sea level">
       <type kind="kind_phys" units="m">real</type>
     </standard_name>
+    <standard_name name="geopotential_height_at_surface"
+                   long_name="geopotential height at local surface">
+      <type kind="kind_phys" units="m">real</type>
+    </standard_name>
     <standard_name name="geopotential_height_wrt_surface"
                    long_name="geopotential height w.r.t. local surface">
       <type kind="kind_phys" units="m">real</type>

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -154,7 +154,8 @@
     <standard_name name="air_pressure_at_sea_level">
       <type kind="kind_phys" units="Pa">real</type>
     </standard_name>
-    <standard_name name="air_pressure_at_surface">
+    <standard_name name="air_pressure_at_surface"
+                   long_name="Air pressure at local surface">
       <type kind="kind_phys" units="Pa">real</type>
     </standard_name>
     <standard_name name="surface_pressure_of_dry_air">
@@ -244,7 +245,7 @@
       <type kind="kind_phys" units="m">real</type>
     </standard_name>
     <standard_name name="geopotential_height_at_surface"
-                   long_name="geopotential height at local surface">
+                   long_name="Geopotential height at local surface w.r.t. sea level">
       <type kind="kind_phys" units="m">real</type>
     </standard_name>
     <standard_name name="geopotential_height_wrt_surface"
@@ -2612,7 +2613,7 @@
          <type kind="kind_phys" units="m">real</type>
       </standard_name>
       <standard_name name="height_above_mean_sea_level_at_surface"
-                     long_name="height above mean sea level at local surface">
+                     long_name="Height above mean sea level at local surface">
          <type kind="kind_phys" units="m">real</type>
       </standard_name>
       <standard_name name="unfiltered_height_above_mean_sea_level">

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -2611,6 +2611,10 @@
       <standard_name name="height_above_mean_sea_level">
          <type kind="kind_phys" units="m">real</type>
       </standard_name>
+      <standard_name name="height_above_mean_sea_level_at_surface"
+                     long_name="height above mean sea level at local surface">
+         <type kind="kind_phys" units="m">real</type>
+      </standard_name>
       <standard_name name="unfiltered_height_above_mean_sea_level">
          <type kind="kind_phys" units="m">real</type>
       </standard_name>

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -154,7 +154,7 @@
     <standard_name name="air_pressure_at_sea_level">
       <type kind="kind_phys" units="Pa">real</type>
     </standard_name>
-    <standard_name name="surface_air_pressure">
+    <standard_name name="air_pressure_at_surface">
       <type kind="kind_phys" units="Pa">real</type>
     </standard_name>
     <standard_name name="surface_pressure_of_dry_air">


### PR DESCRIPTION
This adds two names relating to height at surface, and modifies `surface_air_pressure` for the naming rule change coming in #72.

(I realize that there is more renaming of existing variables to be done as a product of #72, so I can remove `surface_air_pressure` from this PR if people feel it is better to do that rename in a group with the others. It's just that this name is of particular interest to the fast-approaching JEDI renaming code sprint, so I wanted to be sure to get it in.)