### PR TITLE
Update wind derivative/integral names

### DIFF
--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -231,13 +231,13 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = m s-2
 * `tendency_of_northward_wind_due_to_model_physics`: Total change in northward wind from a physics suite
     * `real(kind=kind_phys)`: units = m s-2
-* `atmosphere_horizontal_streamfunction`: Scalar function describing the stream lines of the wind
+* `air_horizontal_streamfunction`: Scalar function describing the stream lines of the wind
     * `real(kind=kind_phys)`: units = m2 s-1
-* `atmosphere_horizontal_velocity_potential`: Scalar potential of the wind
+* `air_horizontal_velocity_potential`: Scalar potential of the wind
     * `real(kind=kind_phys)`: units = m2 s-1
-* `atmosphere_upward_absolute_vorticity`: The curl of the vector wind field
+* `air_upward_absolute_vorticity`: The upward (kth) component of the curl of the vector wind field
     * `real(kind=kind_phys)`: units = s-1
-* `divergence_of_wind`: The (horizontal) divergence of the 2-D vector wind field
+* `air_horizontal_divergence`: The (horizontal) divergence of the 2-D vector wind field
     * `real(kind=kind_phys)`: units = s-1
 * `surface_upward_heat_flux_in_air`: Surface upward heat flux in air
     * `real(kind=kind_phys)`: units = W m-2

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -368,19 +368,19 @@
                    long_name="Total change in northward wind from a physics suite">
       <type kind="kind_phys" units="m s-2">real</type>
     </standard_name>
-    <standard_name name="atmosphere_horizontal_streamfunction"
+    <standard_name name="air_horizontal_streamfunction"
                    long_name="Scalar function describing the stream lines of the wind">
       <type kind="kind_phys" units="m2 s-1">real</type>
     </standard_name>
-    <standard_name name="atmosphere_horizontal_velocity_potential"
+    <standard_name name="air_horizontal_velocity_potential"
                    long_name="Scalar potential of the wind">
       <type kind="kind_phys" units="m2 s-1">real</type>
     </standard_name>
-    <standard_name name="atmosphere_upward_absolute_vorticity"
-                   long_name="The curl of the vector wind field">
+    <standard_name name="air_upward_absolute_vorticity"
+                   long_name="The upward (kth) component of the curl of the vector wind field">
       <type kind="kind_phys" units="s-1">real</type>
     </standard_name>
-    <standard_name name="divergence_of_wind"
+    <standard_name name="air_horizontal_divergence"
                    long_name="The (horizontal) divergence of the 2-D vector wind field">
       <type kind="kind_phys" units="s-1">real</type>
     </standard_name>


### PR DESCRIPTION
Following up on the discussion in https://github.com/ESCOMP/CCPPStandardNames/issues/77, this updates the streamfunction, velocity_potential, vorticity, and divergence names to:

`air_horizontal_streamfunction`
`air_horizontal_velocity_potential`
`air_upward_absolute_vorticity`
`air_horizontal_divergence`

Also, the description of `air_upward_absolute_vorticity` is updated to indicate that it is the kth/upward component of the curl.