### PR TITLE
geopotential height standard name fix

### DIFF
--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -173,7 +173,7 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = m
 * `geopotential_height_wrt_surface`: geopotential height w.r.t. local surface
     * `real(kind=kind_phys)`: units = m
-* `geopotential_height_wrt_surface_at_interface`: geopotential height w.r.t. local surface at interface
+* `geopotential_height_wrt_surface_at_interfaces`: geopotential height w.r.t. local surface at interfaces
     * `real(kind=kind_phys)`: units = m
 * `potentially_advected_quantities`: Potentially advected quantities
     * `real(kind=kind_phys)`: units = various

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -268,8 +268,8 @@
                    long_name="geopotential height w.r.t. local surface">
       <type kind="kind_phys" units="m">real</type>
     </standard_name>
-    <standard_name name="geopotential_height_wrt_surface_at_interface"
-                   long_name="geopotential height w.r.t. local surface at interface">
+    <standard_name name="geopotential_height_wrt_surface_at_interfaces"
+                   long_name="geopotential height w.r.t. local surface at interfaces">
       <type kind="kind_phys" units="m">real</type>
     </standard_name>
     <standard_name name="potentially_advected_quantities">


### PR DESCRIPTION
Found a geopotential height standard name that had the old `at_interface` suffix.  Updated it to match the current `at_interfaces` suffix rule (hopefully before the first tag). 