### PR TITLE
Add/modify skin temperature at surface variables.

### DIFF
--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -1805,7 +1805,7 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = K
 * `skin_temperature_at_surface_over_land`: Skin temperature at surface over (or where) land
     * `real(kind=kind_phys)`: units = K
-* `skin_temperature_at_surface_over_sea`: Skin temperature at surface over (or where)sea
+* `skin_temperature_at_surface_over_sea`: Skin temperature at surface over (or where) sea
     * `real(kind=kind_phys)`: units = K
 * `skin_temperature_at_surface_over_snow`: Skin temperature at surface over (or where) snow
     * `real(kind=kind_phys)`: units = K

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -1787,9 +1787,15 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = cm
 * `surface_roughness_length_over_water`: Surface roughness length over water
     * `real(kind=kind_phys)`: units = cm
-* `surface_skin_temperature`: Surface skin temperature
+* `skin_temperature_at_surface`: Skin temperature at surface
     * `real(kind=kind_phys)`: units = K
-* `surface_skin_temperature_over_land`: Surface skin temperature over land
+* `skin_temperature_at_surface_over_ice`: Skin temperature at surface over (or where) ice
+    * `real(kind=kind_phys)`: units = K
+* `skin_temperature_at_surface_over_land`: Skin temperature at surface over (or where) land
+    * `real(kind=kind_phys)`: units = K
+* `skin_temperature_at_surface_over_sea`: Skin temperature at surface over (or where)sea
+    * `real(kind=kind_phys)`: units = K
+* `skin_temperature_at_surface_over_snow`: Skin temperature at surface over (or where) snow
     * `real(kind=kind_phys)`: units = K
 * `surface_snow_area_fraction_over_ice`: Surface snow area fraction over ice
     * `real(kind=kind_phys)`: units = fraction

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -1805,7 +1805,7 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = K
 * `skin_temperature_at_surface_over_land`: Skin temperature at surface over (or where) land
     * `real(kind=kind_phys)`: units = K
-* `skin_temperature_at_surface_over_sea`: Skin temperature at surface over (or where) sea
+* `skin_temperature_at_surface_over_ocean`: Skin temperature at surface over (or where) ocean
     * `real(kind=kind_phys)`: units = K
 * `skin_temperature_at_surface_over_snow`: Skin temperature at surface over (or where) snow
     * `real(kind=kind_phys)`: units = K

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -2826,7 +2826,8 @@
       <standard_name name="surface_roughness_length_over_water">
          <type kind="kind_phys" units="cm">real</type>
       </standard_name>
-      <standard_name name="skin_temperature_at_surface">
+      <standard_name name="skin_temperature_at_surface"
+                     long_name="Skin temperature at surface">
          <type kind="kind_phys" units="K">real</type>
       </standard_name>
       <standard_name name="skin_temperature_at_surface_over_ice"

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -2829,16 +2829,20 @@
       <standard_name name="skin_temperature_at_surface">
          <type kind="kind_phys" units="K">real</type>
       </standard_name>
-      <standard_name name="skin_temperature_at_surface_over_ice">
+      <standard_name name="skin_temperature_at_surface_over_ice"
+                     long_name="Skin temperature at surface over (or where) ice">
          <type kind="kind_phys" units="K">real</type>
       </standard_name>
-      <standard_name name="skin_temperature_at_surface_over_land">
+      <standard_name name="skin_temperature_at_surface_over_land"
+                     long_name="Skin temperature at surface over (or where) land">
          <type kind="kind_phys" units="K">real</type>
       </standard_name>
-      <standard_name name="skin_temperature_at_surface_over_sea">
+      <standard_name name="skin_temperature_at_surface_over_sea"
+                     long_name="Skin temperature at surface over (or where) sea">
          <type kind="kind_phys" units="K">real</type>
       </standard_name>
-      <standard_name name="skin_temperature_at_surface_over_snow">
+      <standard_name name="skin_temperature_at_surface_over_snow"
+                     long_name="Skin temperature at surface over (or where) snow">
          <type kind="kind_phys" units="K">real</type>
       </standard_name>
       <standard_name name="surface_snow_area_fraction_over_ice">

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -2838,8 +2838,8 @@
                      long_name="Skin temperature at surface over (or where) land">
          <type kind="kind_phys" units="K">real</type>
       </standard_name>
-      <standard_name name="skin_temperature_at_surface_over_sea"
-                     long_name="Skin temperature at surface over (or where) sea">
+      <standard_name name="skin_temperature_at_surface_over_ocean"
+                     long_name="Skin temperature at surface over (or where) ocean">
          <type kind="kind_phys" units="K">real</type>
       </standard_name>
       <standard_name name="skin_temperature_at_surface_over_snow"

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -2801,10 +2801,19 @@
       <standard_name name="surface_roughness_length_over_water">
          <type kind="kind_phys" units="cm">real</type>
       </standard_name>
-      <standard_name name="surface_skin_temperature">
+      <standard_name name="skin_temperature_at_surface">
          <type kind="kind_phys" units="K">real</type>
       </standard_name>
-      <standard_name name="surface_skin_temperature_over_land">
+      <standard_name name="skin_temperature_at_surface_over_ice">
+         <type kind="kind_phys" units="K">real</type>
+      </standard_name>
+      <standard_name name="skin_temperature_at_surface_over_land">
+         <type kind="kind_phys" units="K">real</type>
+      </standard_name>
+      <standard_name name="skin_temperature_at_surface_over_sea">
+         <type kind="kind_phys" units="K">real</type>
+      </standard_name>
+      <standard_name name="skin_temperature_at_surface_over_snow">
          <type kind="kind_phys" units="K">real</type>
       </standard_name>
       <standard_name name="surface_snow_area_fraction_over_ice">


### PR DESCRIPTION
This PR modifies the existing `surface_skin_temperature` name to match the new naming rule introduced in #72. It also adds four new skin temperature variable variants. All these variables were introduced into JEDI during the October 2024 variable naming sprint.

Note a small JEDI/CCPP naming discrepancy discussed in https://github.com/ESCOMP/CCPPStandardNames/issues/83. I attempted to smooth over this difference in the long name.