### PR TITLE
Add field for CF equivalent name

### DIFF
--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -262,10 +262,12 @@ These names are used as bases for other names, but may also be considered standa
 * `virtual_potential_temperature`: The theoretical potential temperature of dry air that would have the same density as moist air
     * `real`: units = K
 * `virtual_temperature`: The theoretical temperature of dry air that would have the same density as moist air
+    * Equivalent CF name: virtual_temperature
     * `real`: units = K
 * `water_vapor`: Water in the gaseous phase
 * `wind`: Movement of air with a net displacement
 * `wind_speed`: Speed of moving air
+    * Equivalent CF name: wind_speed
     * `real`: units = m s-1
 * `wind_stress`: Shear stress exerted by wind parallel to the surface
     * `real`: units = Pa
@@ -617,6 +619,7 @@ Variables defining or relating to timing, dates, calendar, and related concepts
 * `wind_speed_at_surface`: Scalar wind speed closest to surface
     * `real`: units = m s-1
 * `x_wind`: Horizontal wind in a direction perpendicular to y_wind
+    * Equivalent CF name: x_wind
     * `real`: units = m s-1
 * `x_wind_at_surface_adjacent_layer`: X wind at surface adjacent layer
     * `real`: units = m s-1
@@ -625,6 +628,7 @@ Variables defining or relating to timing, dates, calendar, and related concepts
 * `x_wind_of_new_state_at_surface_adjacent_layer`: X wind of new state at surface adjacent layer
     * `real`: units = m s-1
 * `y_wind`: Horizontal wind in a direction perpendicular to x_wind
+    * Equivalent CF name: y_wind
     * `real`: units = m s-1
 * `y_wind_at_surface_adjacent_layer`: Y wind at surface adjacent layer
     * `real`: units = m s-1
@@ -2437,12 +2441,14 @@ Thresholds represent some value at which the behavior of some process changes, i
 * `urban_area_fraction_of_cell_area`: fraction of horizontal area of grid cell that is urban
     * `real`: units = frac
 * `vegetation_area_fraction`: Vegetation area fraction
+    * Equivalent CF name: vegetation_area_fraction
     * `real`: units = fraction
 * `vis_albedo_strong_cosz`: albedo for visible radiation with strong dependence on cosine of the zenith angle
     * `real`: units = fraction
 * `vis_albedo_weak_cosz`: albedo for visible radiation with weak dependence on cosine of the zenith angle
     * `real`: units = fraction
 * `volume_fraction_of_condensed_water_in_soil`: Volume fraction of condensed water in soil
+    * Equivalent CF name: volume_fraction_of_condensed_water_in_soil
     * `real`: units = fraction
 * `volume_fraction_of_frozen_soil_moisture_for_lsm`: Volume fraction of frozen soil moisture for land surface model
     * `real`: units = fraction
@@ -2559,6 +2565,7 @@ Thresholds represent some value at which the behavior of some process changes, i
 * `tendency_of_activated_cloud_condensation_nuclei_from_climatology`: Change of activated cloud condensation nuclei from climatology per unit time
     * `real`: units = kg-1 s-1
 * `tendency_of_air_temperature`: Change in temperature per unit time
+    * Equivalent CF name: tendency_of_air_temperature
     * `real`: units = K s-1
 * `tendency_of_air_temperature_due_to_integrated_dynamics_through_earths_atmosphere`: Tendency of air temperature due to integrated dynamics through earths atmosphere
     * `real`: units = K s-1
@@ -2567,6 +2574,7 @@ Thresholds represent some value at which the behavior of some process changes, i
 * `tendency_of_air_temperature_due_to_longwave_heating_on_radiation_timestep`: Tendency of air temperature due to longwave heating on radiation timestep
     * `real`: units = K s-1
 * `tendency_of_air_temperature_due_to_model_physics`: Change in air temperature due to model physics per unit time
+    * Equivalent CF name: tendency_of_air_temperature_due_to_model_physics
     * `real`: units = K s-1
 * `tendency_of_air_temperature_due_to_nonphysics`: Tendency of air temperature due to nonphysics
     * `real`: units = K s-1
@@ -2577,16 +2585,20 @@ Thresholds represent some value at which the behavior of some process changes, i
 * `tendency_of_dry_air_enthalpy_at_constant_pressure`: Change of dry air enthalpy per unit time at constant pressure; d/dt(Cp*T)
     * `real`: units = J kg-1 s-1
 * `tendency_of_eastward_wind`: Change in eastward wind per unit time
+    * Equivalent CF name: tendency_of_eastward_wind
     * `real`: units = m s-2
 * `tendency_of_eastward_wind_due_to_model_physics`: Change in eastward wind due to model physics per unit time
+    * Equivalent CF name: tendency_of_eastward_wind_due_to_parameterized_physics
     * `real`: units = m s-2
 * `tendency_of_hygroscopic_aerosols_at_surface_adjacent_layer`: Tendency of hygroscopic aerosols at surface adjacent layer
     * `real`: units = kg-1 s-1
 * `tendency_of_nonhygroscopic_ice_nucleating_aerosols_at_surface_adjacent_layer`: Tendency of nonhygroscopic ice nucleating aerosols at surface adjacent layer
     * `real`: units = kg-1 s-1
 * `tendency_of_northward_wind`: Change in northward wind per unit time
+    * Equivalent CF name: tendency_of_northward_wind
     * `real`: units = m s-2
 * `tendency_of_northward_wind_due_to_model_physics`: Change in northward wind due to model physics per unit time
+    * Equivalent CF name: tendency_of_northward_wind_due_to_parameterized_physics
     * `real`: units = m s-2
 * `tendency_of_potential_temperature_of_air`: Change in potential temperature per unit time
     * `real`: units = K s-1

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -156,6 +156,7 @@ These names are used as bases for other names, but may also be considered standa
     * Equivalent CF name: atmosphere_heat_diffusivity
     * `real`: units = m2 s-1
 * `cloud_area_fraction`: Fraction of an area (usually within a grid cell) containing cloud
+    * Equivalent CF name: cloud_area_fraction
     * `real`: units = fraction
 * `cloud_condensate`: Amount of condensed water in cloud
 * `cloud_ice_water`: Cloud particles consisting of solid water (ice)
@@ -327,7 +328,8 @@ Constant parameters that should be identical across a full modeling system
     * `real`: units = m s-2
 ## Coordinates
 Parameters defining or relating to the coordinate system of the model
-* `cell_area`: Cell area
+* `cell_area`: horizontal area of a grid cell
+    * Equivalent CF name: cell_area
     * `real`: units = m2
 * `cell_scaling_factor`: Cell scaling factor
     * `real`: units = 1
@@ -652,6 +654,10 @@ Variables defining or relating to timing, dates, calendar, and related concepts
     * `real`: units = m2 s-1
 * `y_current_in_diurnal_thermocline`: Y current in diurnal thermocline
     * `real`: units = m2 s-1
+* `molecular_sublayer_temperature_correction_in_sea_water`: Molecular sublayer temperature correction in sea water
+    * `real`: units = K
+* `molecular_sublayer_thickness_in_sea_water`: Molecular sublayer thickness in sea water
+    * `real`: units = m
 ## Tracers
 Tracers are numerically zero-mass particles advected in fluid flow, typically representing some trace gas, particle, or other physical substance
 * `chemical_tracer_scavenging_fractions`: Chemical tracer scavenging fractions
@@ -784,6 +790,7 @@ Tracers are numerically zero-mass particles advected in fluid flow, typically re
 * `cloud_condensed_water_mixing_ratio_wrt_moist_air_at_surface_over_land`: Cloud condensed water mass mixing ratio with respect to moist air at surface over land
     * `real`: units = kg kg-1
 * `cloud_ice_mixing_ratio_wrt_dry_air`: Ratio of the mass of cloud ice to the mass of dry air
+    * Equivalent CF name: cloud_ice_mixing_ratio
     * `real`: units = kg kg-1
 * `cloud_ice_mixing_ratio_wrt_dry_air_at_top_interfaces`: Ratio of the mass of cloud ice to the mass of dry air at all interfaces excluding surface
     * `real`: units = kg kg-1
@@ -796,6 +803,7 @@ Tracers are numerically zero-mass particles advected in fluid flow, typically re
 * `cloud_ice_mixing_ratio_wrt_moist_air_of_new_state`: Cloud ice mass mixing ratio with respect to moist air of new state
     * `real`: units = kg kg-1
 * `cloud_liquid_water_mixing_ratio_wrt_dry_air`: Ratio of the mass of cloud liquid water to the mass of dry air
+    * Equivalent CF name: cloud_liquid_water_mixing_ratio
     * `real`: units = kg kg-1
 * `cloud_liquid_water_mixing_ratio_wrt_dry_air_at_top_interfaces`: Ratio of the mass of cloud liquid water to the mass of dry air at all interfaces excluding surface
     * `real`: units = kg kg-1
@@ -812,6 +820,7 @@ Tracers are numerically zero-mass particles advected in fluid flow, typically re
 * `cloud_liquid_water_mixing_ratio_wrt_moist_air_of_new_state`: Cloud liquid water mass mixing ratio with respect to moist air of new state
     * `real`: units = kg kg-1
 * `convective_cloud_area_fraction`: Convective cloud area fraction
+    * Equivalent CF name: convective_cloud_area_fraction
     * `real`: units = fraction
 * `convective_cloud_condensate_after_rainout`: Convective cloud condensate after rainout
     * `real`: units = kg kg-1
@@ -2181,8 +2190,10 @@ Thresholds represent some value at which the behavior of some process changes, i
 * `canopy_intercepted_liquid_water`: Canopy intercepted liquid water
     * `real`: units = mm
 * `canopy_temperature`: Canopy temperature
+    * Equivalent CF name: canopy_temperature
     * `real`: units = K
-* `canopy_water_mass_content`: Canopy water mass content
+* `canopy_water_mass_content`: Water mass per unit area in the canopy
+    * Equivalent CF name: canopy_water_amount
     * `real`: units = kg m-2
 * `cumulative_lwe_thickness_of_convective_precipitation_between_sw_radiation_calls`: Cumulative liquid water equivalent thickness of convective precipitation amount between shortwave radiation calls
     * `real`: units = m
@@ -2287,10 +2298,6 @@ Thresholds represent some value at which the behavior of some process changes, i
 * `mass_content_of_water_in_top_soil_layer`: mass per unit area of water in top layer of soil
     * `real`: units = kg m-2
 * `max_soil_moisture_content_for_lsm`: Maximum soil moisture content for land surface model
-    * `real`: units = m
-* `molecular_sublayer_temperature_correction_in_sea_water`: Molecular sublayer temperature correction in sea water
-    * `real`: units = K
-* `molecular_sublayer_thickness_in_sea_water`: Molecular sublayer thickness in sea water
     * `real`: units = m
 * `nir_albedo_strong_cosz`: albedo for near-infrared radiation with strong dependence on cosine of the zenith angle
     * `real`: units = fraction

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -172,6 +172,7 @@ These names are used as bases for other names, but may also be considered standa
 * `diffuse_vis_albedo`: Albedo of diffuse incident visible radiation
     * `real`: units = 1
 * `dimensionless_exner_function`: Dimensionless formulation of the Exner function with respect to 1000 hPa
+    * Equivalent CF name: dimensionless_exner_function
     * `real`: units = 1
 * `direct_nir_albedo`: Albedo of direct incident near-infrared radiation
     * `real`: units = 1
@@ -196,8 +197,10 @@ These names are used as bases for other names, but may also be considered standa
 * `friction_velocity`: A measure of shear stress within a fluid layer with units of distance per time
     * `real`: units = m s-1
 * `geopotential`: Gravitational potential energy of a unit mass relative to sea level
+    * Equivalent CF name: geopotential
     * `real`: units = m2 s-2
 * `geopotential_height`: Geopotential divided by the gravitational constant
+    * Equivalent CF name: geopotential_height
     * `real`: units = m
 * `graupel`: Precipitation consisting of heavily rimed ice crystals
 * `gravitational_acceleration`: Gravitational acceleration
@@ -210,8 +213,6 @@ These names are used as bases for other names, but may also be considered standa
 * `liquid_water`: Liquid water
 * `longwave_flux`: Flux of longwave radiation across a unit surface
     * `real`: units = W m-2
-* `momentum_flux`: Flux of momentum across a unit surface
-    * `real`: units = Pa
 * `nonhygroscopic_ice_nucleating_aerosols`: Ice-nucleating aerosols with the property of not accumulating liquid water
 * `pressure`: Pressure
     * `real`: units = Pa
@@ -338,12 +339,15 @@ Parameters defining or relating to the coordinate system of the model
 * `cosine_of_latitude`: Cosine of latitude
     * `real`: units = 1
 * `height_above_mean_sea_level`: Height above mean sea level
+    * Equivalent CF name: height_above_mean_sea_level
     * `real`: units = m
 * `height_above_mean_sea_level_at_surface`: Height above mean sea level at local surface
     * `real`: units = m
 * `latitude`: Latitude
+    * Equivalent CF name: latitude
     * `real`: units = degree_north
 * `longitude`: Longitude
+    * Equivalent CF name: longitude
     * `real`: units = degree_east
 * `sigma_pressure_hybrid_coordinate_a_coefficient`: Sigma pressure hybrid coordinate a coefficient
     * `real`: units = Pa
@@ -366,8 +370,6 @@ Variables defining or relating to timing, dates, calendar, and related concepts
     * `real`: units = radian
 * `forecast_julian_day`: Forecast julian day
     * `real`: units = days
-* `forecast_time`: Forecast time
-    * `real`: units = h
 * `forecast_time_in_seconds`: Forecast time in seconds
     * `real`: units = s
 * `forecast_time_on_previous_timestep`: Forecast time on previous timestep
@@ -461,21 +463,19 @@ Variables defining or relating to timing, dates, calendar, and related concepts
 * `dimensionless_exner_function_wrt_surface_pressure`: Dimensionless exner function with respect to surface pressure, (p/ps)^(Rd/cp)
     * `real`: units = 1
 * `dry_static_energy`: Dry static energy content of atmosphere layer
+    * Equivalent CF name: dry_static_energy_content_of_atmosphere_layer
     * `real`: units = J kg-1
 * `eastward_wind`: Wind vector component, positive when directed eastward
+    * Equivalent CF name: eastward_wind
     * `real`: units = m s-1
 * `eastward_wind_at_10m`: Wind vector component at 10 meters above surface, positive when directed eastward
     * `real`: units = m s-1
 * `eastward_wind_at_surface`: Wind vector component closest to surface, positive when directed eastward
     * `real`: units = m s-1
-* `geopotential`: Geopotential
-    * `real`: units = m2 s-2
 * `geopotential_at_interfaces`: Geopotential at interfaces
     * `real`: units = m2 s-2
 * `geopotential_at_surface`: Geopotential at surface
     * `real`: units = m2 s-2
-* `geopotential_height`: geopotential height with respect to sea level
-    * `real`: units = m
 * `geopotential_height_at_interfaces`: Geopotential height at interfaces
     * `real`: units = m
 * `geopotential_height_at_surface`: Geopotential height at local surface with respect to sea level
@@ -487,6 +487,7 @@ Variables defining or relating to timing, dates, calendar, and related concepts
 * `gravitational_acceleration`: Gravitational acceleration
     * `real`: units = m s-2
 * `horizontal_divergence_of_air`: The horizontal divergence of the 2-D vector wind field
+    * Equivalent CF name: divergence_of_wind
     * `real`: units = s-1
 * `horizontal_streamfunction_of_air`: Scalar function describing the streamlines of the horizontal wind
     * `real`: units = m2 s-1
@@ -632,6 +633,10 @@ Variables defining or relating to timing, dates, calendar, and related concepts
     * `real`: units = m
 * `heat_content_in_diurnal_thermocline`: Heat content in diurnal thermocline
     * `real`: units = K m
+* `molecular_sublayer_temperature_correction_in_sea_water`: Molecular sublayer temperature correction in sea water
+    * `real`: units = K
+* `molecular_sublayer_thickness_in_sea_water`: Molecular sublayer thickness in sea water
+    * `real`: units = m
 * `ocean_mixed_layer_thickness`: Ocean mixed layer thickness
     * `real`: units = m
 * `reference_sea_surface_temperature`: Foundation/reference temperature for calculating diurnal ocean temperature changes
@@ -654,10 +659,6 @@ Variables defining or relating to timing, dates, calendar, and related concepts
     * `real`: units = m2 s-1
 * `y_current_in_diurnal_thermocline`: Y current in diurnal thermocline
     * `real`: units = m2 s-1
-* `molecular_sublayer_temperature_correction_in_sea_water`: Molecular sublayer temperature correction in sea water
-    * `real`: units = K
-* `molecular_sublayer_thickness_in_sea_water`: Molecular sublayer thickness in sea water
-    * `real`: units = m
 ## Tracers
 Tracers are numerically zero-mass particles advected in fluid flow, typically representing some trace gas, particle, or other physical substance
 * `chemical_tracer_scavenging_fractions`: Chemical tracer scavenging fractions
@@ -681,10 +682,13 @@ Tracers are numerically zero-mass particles advected in fluid flow, typically re
 * `derivative_of_ln_water_vapor_partial_pressure_assuming_saturation_wrt_air_temperature_at_top_interfaces`: derivative of the natural logarithm of water vapor partial pressure at saturation with respect to air temperature at all interfaces excluding surface
     * `real`: units = K-1
 * `mole_fraction_of_co2_in_air`: Mole fraction of co2 in air
+    * Equivalent CF name: mole_fraction_of_carbon_dioxide_in_air
     * `real`: units = mol mol-1
 * `mole_fraction_of_ozone_in_air`: Mole fraction of ozone in air
+    * Equivalent CF name: mole_fraction_of_ozone_in_air
     * `real`: units = mol mol-1
 * `mole_fraction_of_water_vapor`: Mole fraction of water vapor
+    * Equivalent CF name: mole_fraction_of_water_vapor_in_air
     * `real`: units = mol mol-1
 * `number_density_of_anomalous_oxygen`: Number density of energetic, non-thermal atomic oxygen as defined in MSIS
     * `real`: units = m-3
@@ -829,14 +833,19 @@ Tracers are numerically zero-mass particles advected in fluid flow, typically re
 * `convective_precipitation_rate_on_previous_timestep`: Convective precipitation rate on previous timestep
     * `real`: units = mm s-1
 * `effective_radius_of_stratiform_cloud_graupel_particle`: Effective radius of stratiform cloud graupel particle
+    * Equivalent CF name: effective_radius_of_stratiform_cloud_graupel_particles
     * `real`: units = um
 * `effective_radius_of_stratiform_cloud_ice_particle`: Effective radius of stratiform cloud ice particle
+    * Equivalent CF name: effective_radius_of_stratiform_cloud_ice_particles
     * `real`: units = um
 * `effective_radius_of_stratiform_cloud_liquid_water_particle`: Effective radius of stratiform cloud liquid water particle
+    * Equivalent CF name: effective_radius_of_stratiform_cloud_liquid_water_particles
     * `real`: units = um
 * `effective_radius_of_stratiform_cloud_rain_particle`: Effective radius of stratiform cloud rain particle
+    * Equivalent CF name: effective_radius_of_stratiform_cloud_rain_particles
     * `real`: units = um
 * `effective_radius_of_stratiform_cloud_snow_particle`: Effective radius of stratiform cloud snow particle
+    * Equivalent CF name: effective_radius_of_stratiform_cloud_snow_particles
     * `real`: units = um
 * `graupel_mixing_ratio_wrt_moist_air`: Graupel mass mixing ratio with respect to moist air
     * `real`: units = kg kg-1
@@ -921,13 +930,13 @@ Tracers are numerically zero-mass particles advected in fluid flow, typically re
 ### Aerosols
 * `mass_fraction_of_dust001_in_air`: GOCART Dust bin1 mass fraction
     * `real`: units = kg kg-1
-* `mass_fraction_of_dust002_in_air`: GOCART DUst bin2 mass fraction
+* `mass_fraction_of_dust002_in_air`: GOCART Dust bin2 mass fraction
     * `real`: units = kg kg-1
-* `mass_fraction_of_dust003_in_air`: GOCART DUst bin3 mass fraction
+* `mass_fraction_of_dust003_in_air`: GOCART Dust bin3 mass fraction
     * `real`: units = kg kg-1
-* `mass_fraction_of_dust004_in_air`: GOCART DUst bin4 mass fraction
+* `mass_fraction_of_dust004_in_air`: GOCART Dust bin4 mass fraction
     * `real`: units = kg kg-1
-* `mass_fraction_of_dust005_in_air`: GOCART DUst bin5 mass fraction
+* `mass_fraction_of_dust005_in_air`: GOCART Dust bin5 mass fraction
     * `real`: units = kg kg-1
 * `mass_fraction_of_dust_accumulation_aerosol_particles_in_air`: Mass fraction of accumulation mode dust aerosol particles
     * `real`: units = kg kg-1
@@ -1872,6 +1881,8 @@ Thresholds represent some value at which the behavior of some process changes, i
     * `real`: units = fraction
 * `max_grid_scale`: Maximum grid scale
     * `real`: units = m2 rad-2
+* `max_soil_moisture_content_for_lsm`: Maximum soil moisture content for land surface model
+    * `real`: units = m
 * `max_tendency_of_potential_temperature_of_air_due_to_large_scale_precipitation`: Maximum tendency of air potential temperature due to large-scale precipitation
     * `real`: units = K s-1
 * `max_vegetation_area_fraction`: Maximum vegetation area fraction
@@ -2097,8 +2108,6 @@ Thresholds represent some value at which the behavior of some process changes, i
     * `real`: units = Pa s
 * `cumulative_y_momentum_flux_at_surface_for_coupling_multiplied_by_timestep`: Cumulative y momentum flux at surface for coupling multiplied by timestep
     * `real`: units = Pa s
-* `lwe_surface_snow_from_coupled_process`: Liquid water equivalent surface snow from coupled process
-    * `real`: units = m
 * `monin_obukhov_similarity_function_for_heat`: Monin obukhov similarity function for heat
     * `real`: units = 1
 * `monin_obukhov_similarity_function_for_momentum`: Monin obukhov similarity function for momentum
@@ -2246,6 +2255,7 @@ Thresholds represent some value at which the behavior of some process changes, i
 * `explicit_precipitation_rate_on_previous_timestep`: Explicit precipitation rate on previous timestep
     * `real`: units = mm s-1
 * `fast_soil_pool_mass_content_of_carbon`: Fast soil pool mass content of carbon
+    * Equivalent CF name: fast_soil_pool_mass_content_of_carbon
     * `real`: units = g m-2
 * `fine_root_mass_content`: Fine root mass content
     * `real`: units = g m-2
@@ -2262,19 +2272,24 @@ Thresholds represent some value at which the behavior of some process changes, i
 * `lake_depth`: Lake depth
     * `real`: units = m
 * `land_area_fraction`: Land area fraction
+    * Equivalent CF name: land_area_fraction
     * `real`: units = fraction
 * `land_ice_area_fraction_of_cell_area`: fraction of horizontal area of grid cell that is ice over land
     * `real`: units = frac
 * `land_surface_perturbation_variables`: Land surface perturbation variables
     * `character`: units = none
 * `leaf_area_index`: Leaf area index
+    * Equivalent CF name: leaf_area_index
     * `real`: units = 1
 * `leaf_mass_content`: Leaf mass content
     * `real`: units = g m-2
 * `lwe_snowfall_rate`: Liquid water equivalent snowfall rate
+    * Equivalent CF name: lwe_snowfall_rate
     * `real`: units = mm s-1
 * `lwe_surface_snow`: Liquid water equivalent surface snow
     * `real`: units = mm
+* `lwe_surface_snow_from_coupled_process`: Liquid water equivalent surface snow from coupled process
+    * `real`: units = m
 * `lwe_thickness_of_convective_precipitation_on_previous_timestep`: Liquid water equivalent thickness of convective precipitation amount on previous timestep
     * `real`: units = m
 * `lwe_thickness_of_explicit_precipitation_on_previous_timestep`: Liquid water equivalent thickness of explicit precipitation amount on previous timestep
@@ -2294,11 +2309,10 @@ Thresholds represent some value at which the behavior of some process changes, i
 * `lwe_thickness_of_snowfall_on_previous_timestep`: Liquid water equivalent thickness of snowfall amount on previous timestep
     * `real`: units = mm
 * `lwe_thickness_of_surface_snow`: Liquid water equivalent thickness of surface snow amount
+    * Equivalent CF name: lwe_thickness_of_surface_snow_amount
     * `real`: units = mm
 * `mass_content_of_water_in_top_soil_layer`: mass per unit area of water in top layer of soil
     * `real`: units = kg m-2
-* `max_soil_moisture_content_for_lsm`: Maximum soil moisture content for land surface model
-    * `real`: units = m
 * `nir_albedo_strong_cosz`: albedo for near-infrared radiation with strong dependence on cosine of the zenith angle
     * `real`: units = fraction
 * `nir_albedo_weak_cosz`: albedo for near-infrared radiation with weak dependence on cosine of the zenith angle
@@ -2487,6 +2501,7 @@ Thresholds represent some value at which the behavior of some process changes, i
     * `real`: units = m
 ## Tendencies
 * `lagrangian_tendency_of_air_pressure`: Vertical pressure velocity
+    * Equivalent CF name: lagrangian_tendency_of_air_pressure
     * `real`: units = Pa s-1
 * `process_split_cumulative_tendency_of_air_temperature`: Process split cumulative tendency of air temperature
     * `real`: units = K s-1

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -31,6 +31,7 @@ The following names are too general to be chosen as standard names, but they can
 * `area`: Area
     * `real`: units = m2
 * `area_fraction`: The fraction of an area where some condition applies
+    * Equivalent CF name: area_fraction
     * `real`: units = 1
 * `binary_mask`: A field consisting of either 0 or 1 at every point
     * `integer`: units = 1
@@ -147,10 +148,12 @@ These names are used as bases for other names, but may also be considered standa
 * `air_pressure_thickness`: The difference in air pressure between two vertical layers
     * `real`: units = Pa
 * `air_temperature`: The temperature of air
+    * Equivalent CF name: air_temperature
     * `real`: units = K
 * `albedo`: The fraction of incident radiation reflected by a surface
     * `real`: units = 1
 * `atmosphere_heat_diffusivity`: Atmosphere heat diffusivity
+    * Equivalent CF name: atmosphere_heat_diffusivity
     * `real`: units = m2 s-1
 * `cloud_area_fraction`: Fraction of an area (usually within a grid cell) containing cloud
     * `real`: units = fraction
@@ -345,6 +348,7 @@ Parameters defining or relating to the coordinate system of the model
 * `sigma_pressure_hybrid_coordinate_b_coefficient`: Sigma pressure hybrid coordinate b coefficient
     * `real`: units = 1
 * `sigma_pressure_hybrid_vertical_coordinate`: Sigma pressure hybrid vertical coordinate
+    * Equivalent CF name: atmosphere_hybrid_sigma_pressure_coordinate
     * `real`: units = 1
 * `sine_of_latitude`: Sine of latitude
     * `real`: units = 1
@@ -380,18 +384,22 @@ Variables defining or relating to timing, dates, calendar, and related concepts
     * `real`: units = s
 ## Atmospheric properties
 * `air_pressure`: Midpoint air pressure
+    * Equivalent CF name: air_pressure
     * `real`: units = Pa
 * `air_pressure_at_interfaces`: Air pressure at interfaces
     * `real`: units = Pa
 * `air_pressure_at_lowest_model_interface`: Air pressure at lowest model interface
     * `real`: units = Pa
 * `air_pressure_at_sea_level`: Air pressure at sea level
+    * Equivalent CF name: air_pressure_at_mean_sea_level
     * `real`: units = Pa
 * `air_pressure_at_surface`: Air pressure at local surface
+    * Equivalent CF name: surface_air_pressure
     * `real`: units = Pa
 * `air_pressure_at_surface_adjacent_layer`: Air pressure at surface adjacent layer
     * `real`: units = Pa
 * `air_pressure_at_top_of_atmosphere_model`: Air pressure at top of atmosphere model
+    * Equivalent CF name: air_pressure_at_top_of_atmosphere_model
     * `real`: units = Pa
 * `air_pressure_extended_up_by_1`: Air pressure extended up by 1
     * `real`: units = Pa
@@ -422,6 +430,7 @@ Variables defining or relating to timing, dates, calendar, and related concepts
 * `air_temperature_two_timesteps_back`: Air temperature two timesteps back
     * `real`: units = K
 * `atmosphere_boundary_layer_thickness`: Atmosphere boundary layer thickness
+    * Equivalent CF name: atmosphere_boundary_layer_thickness
     * `real`: units = m
 * `atmosphere_heat_diffusivity_due_to_background`: Atmosphere heat diffusivity due to background
     * `real`: units = m2 s-1
@@ -480,6 +489,7 @@ Variables defining or relating to timing, dates, calendar, and related concepts
 * `horizontal_streamfunction_of_air`: Scalar function describing the streamlines of the horizontal wind
     * `real`: units = m2 s-1
 * `horizontal_velocity_potential_of_air`: Scalar potential of the horizontal wind
+    * Equivalent CF name: atmosphere_horizontal_velocity_potential
     * `real`: units = m2 s-1
 * `is_initialized_physics_grid`: Flag to indicate if physics grid is initialized
     * `logical`: units = flag
@@ -522,6 +532,7 @@ Variables defining or relating to timing, dates, calendar, and related concepts
 * `physics_state_due_to_dynamics`: Physics state due to dynamics
     * `ddt`: units = none
 * `potential_temperature_of_air`: air potential temperature
+    * Equivalent CF name: air_potential_temperature
     * `real`: units = K
 * `potential_temperature_of_air_at_2m`: Potential temperature of air at 2m
     * `real`: units = K
@@ -562,6 +573,7 @@ Variables defining or relating to timing, dates, calendar, and related concepts
 * `timestep_for_physics`: Timestep for physics
     * `integer`: units = s
 * `upward_absolute_vorticity_of_air`: The upward (kth) component of the curl of the vector wind field
+    * Equivalent CF name: atmosphere_upward_absolute_vorticity
     * `real`: units = s-1
 * `upward_heat_flux_in_air_at_surface`: Upward heat flux in air at surface
     * `real`: units = W m-2
@@ -747,10 +759,12 @@ Tracers are numerically zero-mass particles advected in fluid flow, typically re
 * `volume_mixing_ratio_of_so2`: Sulfur dioxide volume mixing ratio
     * `real`: units = mol mol-1
 * `water_vapor_mixing_ratio_wrt_dry_air`: Ratio of the mass of water vapor to the mass of dry air
+    * Equivalent CF name: humidity_mixing_ratio
     * `real`: units = kg kg-1
 * `water_vapor_mixing_ratio_wrt_dry_air_at_top_interfaces`: Ratio of the mass of water vapor to the mass of dry air at all interfaces excluding surface
     * `real`: units = kg kg-1
 * `water_vapor_mixing_ratio_wrt_moist_air`: Ratio of the mass of water vapor to the mass of moist air
+    * Equivalent CF name: specific_humidity
     * `real`: units = kg kg-1
 * `water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water`: Ratio of the mass of water vapor to the mass of moist air and hydrometeors
     * `real`: units = kg kg-1
@@ -2154,6 +2168,7 @@ Thresholds represent some value at which the behavior of some process changes, i
 * `albedo_on_previous_timestep_assuming_deep_snow`: Albedo on previous timestep assuming deep snow
     * `real`: units = fraction
 * `area_type`: Area type
+    * Equivalent CF name: area_type
     * `real`: units = 1
 * `area_type_from_coupled_process`: Area type from coupled process
     * `real`: units = 1

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -222,6 +222,7 @@ These names are used as bases for other names, but may also be considered standa
 * `random_number_seed`: Random number seed
     * `integer`: units = 1
 * `reference_pressure`: Some pressure value for comparison to or calculation of other values
+    * Equivalent CF name: reference_pressure
     * `real`: units = Pa
 * `relative_humidity`: Ratio of the vapor pressure to the saturation vapor pressure (for liquid water unless otherwise specified)
     * `real`: units = fraction
@@ -236,10 +237,15 @@ These names are used as bases for other names, but may also be considered standa
     * `real`: units = fraction
 * `soil_moisture`: Water contained within a soil layer
 * `soil_temperature`: Temperature of a soil layer
+    * Equivalent CF name: soil_temperature
     * `real`: units = K
 * `solar_declination_angle`: The angle between the equator and Earth's orbital plane with the Sun
+    * `real`: units = degrees
 * `solar_zenith_angle`: The angle between the direction to the sun and the local zenith (vertical direction)
+    * Equivalent CF name: solar_zenith_angle
+    * `real`: units = degrees
 * `surface_skin_temperature`: The temperature of the topmost layer of the surface
+    * Equivalent CF name: surface_skin_temperature
     * `real`: units = K
 * `temperature`: Temperature
     * `real`: units = K
@@ -525,8 +531,10 @@ Variables defining or relating to timing, dates, calendar, and related concepts
 * `nonadvected_tke_multiplied_by_2`: Non-advected turbulent kinetic energy multiplied by 2
     * `real`: units = m2 s-2
 * `nonconvective_cloud_area_fraction_in_atmosphere_layer`: cloud area fraction in atmosphere layer excluding clouds produced by the convective schemes
+    * Equivalent CF name: stratiform_cloud_area_fraction_in_atmosphere_layer
     * `real`: units = fraction
 * `northward_wind`: Wind vector component, positive when directed northward
+    * Equivalent CF name: northward_wind
     * `real`: units = m s-1
 * `northward_wind_at_10m`: Wind vector component at 10 meters above surface, positive when directed northward
     * `real`: units = m s-1
@@ -558,6 +566,7 @@ Variables defining or relating to timing, dates, calendar, and related concepts
 * `reference_pressure_in_atmosphere_layer_normalized_by_surface_reference_pressure`: Reference pressure in atmosphere layer normalized by surface reference pressure
     * `real`: units = 1
 * `relative_humidity`: Relative humidity
+    * Equivalent CF name: relative_humidity
     * `real`: units = fraction
 * `relative_humidity_at_2m`: Relative humidity at 2m
     * `real`: units = fraction
@@ -579,6 +588,7 @@ Variables defining or relating to timing, dates, calendar, and related concepts
     * Equivalent CF name: atmosphere_upward_absolute_vorticity
     * `real`: units = s-1
 * `upward_heat_flux_in_air_at_surface`: Upward heat flux in air at surface
+    * Equivalent CF name: surface_upward_heat_flux_in_air
     * `real`: units = W m-2
 * `us_standard_air_pressure_at_sea_level`: US Standard Atmospheric pressure at sea level
     * `real`: units = Pa
@@ -638,22 +648,29 @@ Variables defining or relating to timing, dates, calendar, and related concepts
 * `molecular_sublayer_thickness_in_sea_water`: Molecular sublayer thickness in sea water
     * `real`: units = m
 * `ocean_mixed_layer_thickness`: Ocean mixed layer thickness
+    * Equivalent CF name: ocean_mixed_layer_thickness
     * `real`: units = m
 * `reference_sea_surface_temperature`: Foundation/reference temperature for calculating diurnal ocean temperature changes
     * `real`: units = K
 * `sea_surface_temperature`: Sea surface temperature
+    * Equivalent CF name: sea_surface_temperature
     * `real`: units = K
 * `sea_water_absolute_salinity`: The absolute salinity of sea water
+    * Equivalent CF name: sea_water_absolute_salinity
     * `real`: units = g kg-1
 * `sea_water_depth`: The depth of the ocean floor below the surface of the sea
+    * Equivalent CF name: sea_floor_depth_below_geoid
     * `real`: units = m
 * `sea_water_potential_temperature`: sea water potential temperature
+    * Equivalent CF name: sea_water_potential_temperature
     * `real`: units = K
 * `sea_water_practical_salinity`: The practical salinity of sea water
+    * Equivalent CF name: sea_water_practical_salinity
     * `real`: units = PSU
 * `sea_water_salinity_in_diurnal_thermocline`: Sea water salinity in diurnal thermocline
     * `real`: units = ppt m
 * `sea_water_temperature`: The temperature of sea water
+    * Equivalent CF name: sea_water_temperature
     * `real`: units = K
 * `x_current_in_diurnal_thermocline`: X current in diurnal thermocline
     * `real`: units = m2 s-1
@@ -2214,7 +2231,8 @@ Thresholds represent some value at which the behavior of some process changes, i
     * `real`: units = m
 * `deep_soil_temperature`: Deep soil temperature
     * `real`: units = K
-* `density_of_snow_at_surface`: Density of snow at surface
+* `density_of_snow_at_surface`: Density of snow accumulated on ground surface
+    * Equivalent CF name: surface_snow_density
     * `real`: units = kg m-3
 * `depth_from_snow_surface_at_bottom_interface`: depth from the top of the snow surface at the bottom of the soil layer
     * `real`: units = m
@@ -2275,6 +2293,7 @@ Thresholds represent some value at which the behavior of some process changes, i
     * Equivalent CF name: land_area_fraction
     * `real`: units = fraction
 * `land_ice_area_fraction_of_cell_area`: fraction of horizontal area of grid cell that is ice over land
+    * Equivalent CF name: land_ice_area_fraction
     * `real`: units = frac
 * `land_surface_perturbation_variables`: Land surface perturbation variables
     * `character`: units = none
@@ -2322,6 +2341,7 @@ Thresholds represent some value at which the behavior of some process changes, i
 * `normalized_soil_wetness_for_lsm`: Normalized soil wetness for land surface model
     * `real`: units = fraction
 * `roughness_length`: surface roughness length
+    * Equivalent CF name: surface_roughness_length
     * `real`: units = cm
 * `roughness_length_from_wave_model`: surface roughness length from wave model
     * `real`: units = cm
@@ -2336,11 +2356,11 @@ Thresholds represent some value at which the behavior of some process changes, i
 * `sea_ice_area_fraction_of_sea_area_fraction`: Sea ice area fraction of sea area fraction
     * `real`: units = fraction
 * `sea_ice_temperature`: Sea ice temperature
+    * Equivalent CF name: sea_ice_temperature
     * `real`: units = K
 * `sea_ice_thickness`: Sea ice thickness
+    * Equivalent CF name: sea_ice_thickness
     * `real`: units = m
-* `skin_temperature_at_surface`: Skin temperature at surface
-    * `real`: units = K
 * `skin_temperature_at_surface_over_ice`: Skin temperature at surface over (or where) ice
     * `real`: units = K
 * `skin_temperature_at_surface_over_land`: Skin temperature at surface over (or where) land
@@ -2350,6 +2370,7 @@ Thresholds represent some value at which the behavior of some process changes, i
 * `skin_temperature_at_surface_over_snow`: Skin temperature at surface over (or where) snow
     * `real`: units = K
 * `slow_soil_pool_mass_content_of_carbon`: Slow soil pool mass content of carbon
+    * Equivalent CF name: slow_soil_pool_mass_content_of_carbon
     * `real`: units = g m-2
 * `snow_area_fraction_at_surface_over_ice`: Snow area fraction at surface over ice
     * `real`: units = fraction
@@ -2359,8 +2380,6 @@ Thresholds represent some value at which the behavior of some process changes, i
     * `real`: units = m
 * `snowfall_rate_on_previous_timestep`: Snowfall rate on previous timestep
     * `real`: units = mm s-1
-* `soil_temperature`: Soil temperature
-    * `real`: units = K
 * `soil_temperature_for_lsm`: Soil temperature for land surface model
     * `real`: units = K
 * `specified_upward_flux_of_water_vapor_mixing_ratio_wrt_moist_air_at_surface`: Specified upward specific humidity (water vapor mass mixing ratio with respect to moist air) flux at surface
@@ -2382,6 +2401,7 @@ Thresholds represent some value at which the behavior of some process changes, i
 * `surface_friction_velocity_for_momentum`: Surface friction velocity for momentum
     * `real`: units = m s-1
 * `surface_longwave_emissivity`: Surface longwave emissivity
+    * Equivalent CF name: surface_longwave_emissivity
     * `real`: units = fraction
 * `surface_longwave_emissivity_over_ice`: Surface longwave emissivity over ice
     * `real`: units = fraction
@@ -2412,6 +2432,7 @@ Thresholds represent some value at which the behavior of some process changes, i
 * `upper_bound_of_max_albedo_assuming_deep_snow`: Upper bound of maximum albedo assuming deep snow
     * `real`: units = fraction
 * `upward_latent_heat_flux_at_surface`: Upward latent heat flux at surface
+    * Equivalent CF name: surface_upward_latent_heat_flux
     * `real`: units = W m-2
 * `urban_area_fraction_of_cell_area`: fraction of horizontal area of grid cell that is urban
     * `real`: units = frac

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -31,7 +31,7 @@ The following names are too general to be chosen as standard names, but they can
 * `area`: Area
     * `real`: units = m2
 * `area_fraction`: The fraction of an area where some condition applies
-    * `Equivalent CF name`: area_fraction
+    * Equivalent CF name: `area_fraction`
     * `real`: units = 1
 * `binary_mask`: A field consisting of either 0 or 1 at every point
     * `integer`: units = 1
@@ -148,15 +148,15 @@ These names are used as bases for other names, but may also be considered standa
 * `air_pressure_thickness`: The difference in air pressure between two vertical layers
     * `real`: units = Pa
 * `air_temperature`: The temperature of air
-    * `Equivalent CF name`: air_temperature
+    * Equivalent CF name: `air_temperature`
     * `real`: units = K
 * `albedo`: The fraction of incident radiation reflected by a surface
     * `real`: units = 1
 * `atmosphere_heat_diffusivity`: Atmosphere heat diffusivity
-    * `Equivalent CF name`: atmosphere_heat_diffusivity
+    * Equivalent CF name: `atmosphere_heat_diffusivity`
     * `real`: units = m2 s-1
 * `cloud_area_fraction`: Fraction of an area (usually within a grid cell) containing cloud
-    * `Equivalent CF name`: cloud_area_fraction
+    * Equivalent CF name: `cloud_area_fraction`
     * `real`: units = fraction
 * `cloud_condensate`: Amount of condensed water in cloud
 * `cloud_ice_water`: Cloud particles consisting of solid water (ice)
@@ -172,7 +172,7 @@ These names are used as bases for other names, but may also be considered standa
 * `diffuse_vis_albedo`: Albedo of diffuse incident visible radiation
     * `real`: units = 1
 * `dimensionless_exner_function`: Dimensionless formulation of the Exner function with respect to 1000 hPa
-    * `Equivalent CF name`: dimensionless_exner_function
+    * Equivalent CF name: `dimensionless_exner_function`
     * `real`: units = 1
 * `direct_nir_albedo`: Albedo of direct incident near-infrared radiation
     * `real`: units = 1
@@ -197,10 +197,10 @@ These names are used as bases for other names, but may also be considered standa
 * `friction_velocity`: A measure of shear stress within a fluid layer with units of distance per time
     * `real`: units = m s-1
 * `geopotential`: Gravitational potential energy of a unit mass relative to sea level
-    * `Equivalent CF name`: geopotential
+    * Equivalent CF name: `geopotential`
     * `real`: units = m2 s-2
 * `geopotential_height`: Geopotential divided by the gravitational constant
-    * `Equivalent CF name`: geopotential_height
+    * Equivalent CF name: `geopotential_height`
     * `real`: units = m
 * `graupel`: Precipitation consisting of heavily rimed ice crystals
 * `gravitational_acceleration`: Gravitational acceleration
@@ -222,7 +222,7 @@ These names are used as bases for other names, but may also be considered standa
 * `random_number_seed`: Random number seed
     * `integer`: units = 1
 * `reference_pressure`: Some pressure value for comparison to or calculation of other values
-    * `Equivalent CF name`: reference_pressure
+    * Equivalent CF name: `reference_pressure`
     * `real`: units = Pa
 * `relative_humidity`: Ratio of the vapor pressure to the saturation vapor pressure (for liquid water unless otherwise specified)
     * `real`: units = fraction
@@ -237,15 +237,15 @@ These names are used as bases for other names, but may also be considered standa
     * `real`: units = fraction
 * `soil_moisture`: Water contained within a soil layer
 * `soil_temperature`: Temperature of a soil layer
-    * `Equivalent CF name`: soil_temperature
+    * Equivalent CF name: `soil_temperature`
     * `real`: units = K
 * `solar_declination_angle`: The angle between the equator and Earth's orbital plane with the Sun
     * `real`: units = degrees
 * `solar_zenith_angle`: The angle between the direction to the sun and the local zenith (vertical direction)
-    * `Equivalent CF name`: solar_zenith_angle
+    * Equivalent CF name: `solar_zenith_angle`
     * `real`: units = degrees
 * `surface_skin_temperature`: The temperature of the topmost layer of the surface
-    * `Equivalent CF name`: surface_skin_temperature
+    * Equivalent CF name: `surface_skin_temperature`
     * `real`: units = K
 * `temperature`: Temperature
     * `real`: units = K
@@ -262,12 +262,12 @@ These names are used as bases for other names, but may also be considered standa
 * `virtual_potential_temperature`: The theoretical potential temperature of dry air that would have the same density as moist air
     * `real`: units = K
 * `virtual_temperature`: The theoretical temperature of dry air that would have the same density as moist air
-    * `Equivalent CF name`: virtual_temperature
+    * Equivalent CF name: `virtual_temperature`
     * `real`: units = K
 * `water_vapor`: Water in the gaseous phase
 * `wind`: Movement of air with a net displacement
 * `wind_speed`: Speed of moving air
-    * `Equivalent CF name`: wind_speed
+    * Equivalent CF name: `wind_speed`
     * `real`: units = m s-1
 * `wind_stress`: Shear stress exerted by wind parallel to the surface
     * `real`: units = Pa
@@ -338,7 +338,7 @@ Constant parameters that should be identical across a full modeling system
 ## Coordinates
 Parameters defining or relating to the coordinate system of the model
 * `cell_area`: horizontal area of a grid cell
-    * `Equivalent CF name`: cell_area
+    * Equivalent CF name: `cell_area`
     * `real`: units = m2
 * `cell_scaling_factor`: Cell scaling factor
     * `real`: units = 1
@@ -347,22 +347,22 @@ Parameters defining or relating to the coordinate system of the model
 * `cosine_of_latitude`: Cosine of latitude
     * `real`: units = 1
 * `height_above_mean_sea_level`: Height above mean sea level
-    * `Equivalent CF name`: height_above_mean_sea_level
+    * Equivalent CF name: `height_above_mean_sea_level`
     * `real`: units = m
 * `height_above_mean_sea_level_at_surface`: Height above mean sea level at local surface
     * `real`: units = m
 * `latitude`: Latitude
-    * `Equivalent CF name`: latitude
+    * Equivalent CF name: `latitude`
     * `real`: units = degree_north
 * `longitude`: Longitude
-    * `Equivalent CF name`: longitude
+    * Equivalent CF name: `longitude`
     * `real`: units = degree_east
 * `sigma_pressure_hybrid_coordinate_a_coefficient`: Sigma pressure hybrid coordinate a coefficient
     * `real`: units = Pa
 * `sigma_pressure_hybrid_coordinate_b_coefficient`: Sigma pressure hybrid coordinate b coefficient
     * `real`: units = 1
 * `sigma_pressure_hybrid_vertical_coordinate`: Sigma pressure hybrid vertical coordinate
-    * `Equivalent CF name`: atmosphere_hybrid_sigma_pressure_coordinate
+    * Equivalent CF name: `atmosphere_hybrid_sigma_pressure_coordinate`
     * `real`: units = 1
 * `sine_of_latitude`: Sine of latitude
     * `real`: units = 1
@@ -396,22 +396,22 @@ Variables defining or relating to timing, dates, calendar, and related concepts
     * `real`: units = s
 ## Atmospheric properties
 * `air_pressure`: Midpoint air pressure
-    * `Equivalent CF name`: air_pressure
+    * Equivalent CF name: `air_pressure`
     * `real`: units = Pa
 * `air_pressure_at_interfaces`: Air pressure at interfaces
     * `real`: units = Pa
 * `air_pressure_at_lowest_model_interface`: Air pressure at lowest model interface
     * `real`: units = Pa
 * `air_pressure_at_sea_level`: Air pressure at sea level
-    * `Equivalent CF name`: air_pressure_at_mean_sea_level
+    * Equivalent CF name: `air_pressure_at_mean_sea_level`
     * `real`: units = Pa
 * `air_pressure_at_surface`: Air pressure at local surface
-    * `Equivalent CF name`: surface_air_pressure
+    * Equivalent CF name: `surface_air_pressure`
     * `real`: units = Pa
 * `air_pressure_at_surface_adjacent_layer`: Air pressure at surface adjacent layer
     * `real`: units = Pa
 * `air_pressure_at_top_of_atmosphere_model`: Air pressure at top of atmosphere model
-    * `Equivalent CF name`: air_pressure_at_top_of_atmosphere_model
+    * Equivalent CF name: `air_pressure_at_top_of_atmosphere_model`
     * `real`: units = Pa
 * `air_pressure_extended_up_by_1`: Air pressure extended up by 1
     * `real`: units = Pa
@@ -442,7 +442,7 @@ Variables defining or relating to timing, dates, calendar, and related concepts
 * `air_temperature_two_timesteps_back`: Air temperature two timesteps back
     * `real`: units = K
 * `atmosphere_boundary_layer_thickness`: Atmosphere boundary layer thickness
-    * `Equivalent CF name`: atmosphere_boundary_layer_thickness
+    * Equivalent CF name: `atmosphere_boundary_layer_thickness`
     * `real`: units = m
 * `atmosphere_heat_diffusivity_due_to_background`: Atmosphere heat diffusivity due to background
     * `real`: units = m2 s-1
@@ -471,10 +471,10 @@ Variables defining or relating to timing, dates, calendar, and related concepts
 * `dimensionless_exner_function_wrt_surface_pressure`: Dimensionless exner function with respect to surface pressure, (p/ps)^(Rd/cp)
     * `real`: units = 1
 * `dry_static_energy`: Dry static energy content of atmosphere layer
-    * `Equivalent CF name`: dry_static_energy_content_of_atmosphere_layer
+    * Equivalent CF name: `dry_static_energy_content_of_atmosphere_layer`
     * `real`: units = J kg-1
 * `eastward_wind`: Wind vector component, positive when directed eastward
-    * `Equivalent CF name`: eastward_wind
+    * Equivalent CF name: `eastward_wind`
     * `real`: units = m s-1
 * `eastward_wind_at_10m`: Wind vector component at 10 meters above surface, positive when directed eastward
     * `real`: units = m s-1
@@ -495,12 +495,12 @@ Variables defining or relating to timing, dates, calendar, and related concepts
 * `gravitational_acceleration`: Gravitational acceleration
     * `real`: units = m s-2
 * `horizontal_divergence_of_air`: The horizontal divergence of the 2-D vector wind field
-    * `Equivalent CF name`: divergence_of_wind
+    * Equivalent CF name: `divergence_of_wind`
     * `real`: units = s-1
 * `horizontal_streamfunction_of_air`: Scalar function describing the streamlines of the horizontal wind
     * `real`: units = m2 s-1
 * `horizontal_velocity_potential_of_air`: Scalar potential of the horizontal wind
-    * `Equivalent CF name`: atmosphere_horizontal_velocity_potential
+    * Equivalent CF name: `atmosphere_horizontal_velocity_potential`
     * `real`: units = m2 s-1
 * `is_initialized_physics_grid`: Flag to indicate if physics grid is initialized
     * `logical`: units = flag
@@ -533,10 +533,10 @@ Variables defining or relating to timing, dates, calendar, and related concepts
 * `nonadvected_tke_multiplied_by_2`: Non-advected turbulent kinetic energy multiplied by 2
     * `real`: units = m2 s-2
 * `nonconvective_cloud_area_fraction_in_atmosphere_layer`: cloud area fraction in atmosphere layer excluding clouds produced by the convective schemes
-    * `Equivalent CF name`: stratiform_cloud_area_fraction_in_atmosphere_layer
+    * Equivalent CF name: `stratiform_cloud_area_fraction_in_atmosphere_layer`
     * `real`: units = fraction
 * `northward_wind`: Wind vector component, positive when directed northward
-    * `Equivalent CF name`: northward_wind
+    * Equivalent CF name: `northward_wind`
     * `real`: units = m s-1
 * `northward_wind_at_10m`: Wind vector component at 10 meters above surface, positive when directed northward
     * `real`: units = m s-1
@@ -545,7 +545,7 @@ Variables defining or relating to timing, dates, calendar, and related concepts
 * `physics_state_due_to_dynamics`: Physics state due to dynamics
     * `ddt`: units = none
 * `potential_temperature_of_air`: air potential temperature
-    * `Equivalent CF name`: air_potential_temperature
+    * Equivalent CF name: `air_potential_temperature`
     * `real`: units = K
 * `potential_temperature_of_air_at_2m`: Potential temperature of air at 2m
     * `real`: units = K
@@ -568,7 +568,7 @@ Variables defining or relating to timing, dates, calendar, and related concepts
 * `reference_pressure_in_atmosphere_layer_normalized_by_surface_reference_pressure`: Reference pressure in atmosphere layer normalized by surface reference pressure
     * `real`: units = 1
 * `relative_humidity`: Relative humidity
-    * `Equivalent CF name`: relative_humidity
+    * Equivalent CF name: `relative_humidity`
     * `real`: units = fraction
 * `relative_humidity_at_2m`: Relative humidity at 2m
     * `real`: units = fraction
@@ -587,10 +587,10 @@ Variables defining or relating to timing, dates, calendar, and related concepts
 * `timestep_for_physics`: Timestep for physics
     * `integer`: units = s
 * `upward_absolute_vorticity_of_air`: The upward (kth) component of the curl of the vector wind field
-    * `Equivalent CF name`: atmosphere_upward_absolute_vorticity
+    * Equivalent CF name: `atmosphere_upward_absolute_vorticity`
     * `real`: units = s-1
 * `upward_heat_flux_in_air_at_surface`: Upward heat flux in air at surface
-    * `Equivalent CF name`: surface_upward_heat_flux_in_air
+    * Equivalent CF name: `surface_upward_heat_flux_in_air`
     * `real`: units = W m-2
 * `us_standard_air_pressure_at_sea_level`: US Standard Atmospheric pressure at sea level
     * `real`: units = Pa
@@ -619,7 +619,7 @@ Variables defining or relating to timing, dates, calendar, and related concepts
 * `wind_speed_at_surface`: Scalar wind speed closest to surface
     * `real`: units = m s-1
 * `x_wind`: Horizontal wind in a direction perpendicular to y_wind
-    * `Equivalent CF name`: x_wind
+    * Equivalent CF name: `x_wind`
     * `real`: units = m s-1
 * `x_wind_at_surface_adjacent_layer`: X wind at surface adjacent layer
     * `real`: units = m s-1
@@ -628,7 +628,7 @@ Variables defining or relating to timing, dates, calendar, and related concepts
 * `x_wind_of_new_state_at_surface_adjacent_layer`: X wind of new state at surface adjacent layer
     * `real`: units = m s-1
 * `y_wind`: Horizontal wind in a direction perpendicular to x_wind
-    * `Equivalent CF name`: y_wind
+    * Equivalent CF name: `y_wind`
     * `real`: units = m s-1
 * `y_wind_at_surface_adjacent_layer`: Y wind at surface adjacent layer
     * `real`: units = m s-1
@@ -652,29 +652,29 @@ Variables defining or relating to timing, dates, calendar, and related concepts
 * `molecular_sublayer_thickness_in_sea_water`: Molecular sublayer thickness in sea water
     * `real`: units = m
 * `ocean_mixed_layer_thickness`: Ocean mixed layer thickness
-    * `Equivalent CF name`: ocean_mixed_layer_thickness
+    * Equivalent CF name: `ocean_mixed_layer_thickness`
     * `real`: units = m
 * `reference_sea_surface_temperature`: Foundation/reference temperature for calculating diurnal ocean temperature changes
     * `real`: units = K
 * `sea_surface_temperature`: Sea surface temperature
-    * `Equivalent CF name`: sea_surface_temperature
+    * Equivalent CF name: `sea_surface_temperature`
     * `real`: units = K
 * `sea_water_absolute_salinity`: The absolute salinity of sea water
-    * `Equivalent CF name`: sea_water_absolute_salinity
+    * Equivalent CF name: `sea_water_absolute_salinity`
     * `real`: units = g kg-1
 * `sea_water_depth`: The depth of the ocean floor below the surface of the sea
-    * `Equivalent CF name`: sea_floor_depth_below_geoid
+    * Equivalent CF name: `sea_floor_depth_below_geoid`
     * `real`: units = m
 * `sea_water_potential_temperature`: sea water potential temperature
-    * `Equivalent CF name`: sea_water_potential_temperature
+    * Equivalent CF name: `sea_water_potential_temperature`
     * `real`: units = K
 * `sea_water_practical_salinity`: The practical salinity of sea water
-    * `Equivalent CF name`: sea_water_practical_salinity
+    * Equivalent CF name: `sea_water_practical_salinity`
     * `real`: units = PSU
 * `sea_water_salinity_in_diurnal_thermocline`: Sea water salinity in diurnal thermocline
     * `real`: units = ppt m
 * `sea_water_temperature`: The temperature of sea water
-    * `Equivalent CF name`: sea_water_temperature
+    * Equivalent CF name: `sea_water_temperature`
     * `real`: units = K
 * `x_current_in_diurnal_thermocline`: X current in diurnal thermocline
     * `real`: units = m2 s-1
@@ -703,13 +703,13 @@ Tracers are numerically zero-mass particles advected in fluid flow, typically re
 * `derivative_of_ln_water_vapor_partial_pressure_assuming_saturation_wrt_air_temperature_at_top_interfaces`: derivative of the natural logarithm of water vapor partial pressure at saturation with respect to air temperature at all interfaces excluding surface
     * `real`: units = K-1
 * `mole_fraction_of_co2_in_air`: Mole fraction of co2 in air
-    * `Equivalent CF name`: mole_fraction_of_carbon_dioxide_in_air
+    * Equivalent CF name: `mole_fraction_of_carbon_dioxide_in_air`
     * `real`: units = mol mol-1
 * `mole_fraction_of_ozone_in_air`: Mole fraction of ozone in air
-    * `Equivalent CF name`: mole_fraction_of_ozone_in_air
+    * Equivalent CF name: `mole_fraction_of_ozone_in_air`
     * `real`: units = mol mol-1
 * `mole_fraction_of_water_vapor`: Mole fraction of water vapor
-    * `Equivalent CF name`: mole_fraction_of_water_vapor_in_air
+    * Equivalent CF name: `mole_fraction_of_water_vapor_in_air`
     * `real`: units = mol mol-1
 * `number_density_of_anomalous_oxygen`: Number density of energetic, non-thermal atomic oxygen as defined in MSIS
     * `real`: units = m-3
@@ -790,12 +790,12 @@ Tracers are numerically zero-mass particles advected in fluid flow, typically re
 * `volume_mixing_ratio_of_so2`: Sulfur dioxide volume mixing ratio
     * `real`: units = mol mol-1
 * `water_vapor_mixing_ratio_wrt_dry_air`: Ratio of the mass of water vapor to the mass of dry air
-    * `Equivalent CF name`: humidity_mixing_ratio
+    * Equivalent CF name: `humidity_mixing_ratio`
     * `real`: units = kg kg-1
 * `water_vapor_mixing_ratio_wrt_dry_air_at_top_interfaces`: Ratio of the mass of water vapor to the mass of dry air at all interfaces excluding surface
     * `real`: units = kg kg-1
 * `water_vapor_mixing_ratio_wrt_moist_air`: Ratio of the mass of water vapor to the mass of moist air
-    * `Equivalent CF name`: specific_humidity
+    * Equivalent CF name: `specific_humidity`
     * `real`: units = kg kg-1
 * `water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water`: Ratio of the mass of water vapor to the mass of moist air and hydrometeors
     * `real`: units = kg kg-1
@@ -815,7 +815,7 @@ Tracers are numerically zero-mass particles advected in fluid flow, typically re
 * `cloud_condensed_water_mixing_ratio_wrt_moist_air_at_surface_over_land`: Cloud condensed water mass mixing ratio with respect to moist air at surface over land
     * `real`: units = kg kg-1
 * `cloud_ice_mixing_ratio_wrt_dry_air`: Ratio of the mass of cloud ice to the mass of dry air
-    * `Equivalent CF name`: cloud_ice_mixing_ratio
+    * Equivalent CF name: `cloud_ice_mixing_ratio`
     * `real`: units = kg kg-1
 * `cloud_ice_mixing_ratio_wrt_dry_air_at_top_interfaces`: Ratio of the mass of cloud ice to the mass of dry air at all interfaces excluding surface
     * `real`: units = kg kg-1
@@ -828,7 +828,7 @@ Tracers are numerically zero-mass particles advected in fluid flow, typically re
 * `cloud_ice_mixing_ratio_wrt_moist_air_of_new_state`: Cloud ice mass mixing ratio with respect to moist air of new state
     * `real`: units = kg kg-1
 * `cloud_liquid_water_mixing_ratio_wrt_dry_air`: Ratio of the mass of cloud liquid water to the mass of dry air
-    * `Equivalent CF name`: cloud_liquid_water_mixing_ratio
+    * Equivalent CF name: `cloud_liquid_water_mixing_ratio`
     * `real`: units = kg kg-1
 * `cloud_liquid_water_mixing_ratio_wrt_dry_air_at_top_interfaces`: Ratio of the mass of cloud liquid water to the mass of dry air at all interfaces excluding surface
     * `real`: units = kg kg-1
@@ -845,7 +845,7 @@ Tracers are numerically zero-mass particles advected in fluid flow, typically re
 * `cloud_liquid_water_mixing_ratio_wrt_moist_air_of_new_state`: Cloud liquid water mass mixing ratio with respect to moist air of new state
     * `real`: units = kg kg-1
 * `convective_cloud_area_fraction`: Convective cloud area fraction
-    * `Equivalent CF name`: convective_cloud_area_fraction
+    * Equivalent CF name: `convective_cloud_area_fraction`
     * `real`: units = fraction
 * `convective_cloud_condensate_after_rainout`: Convective cloud condensate after rainout
     * `real`: units = kg kg-1
@@ -854,19 +854,19 @@ Tracers are numerically zero-mass particles advected in fluid flow, typically re
 * `convective_precipitation_rate_on_previous_timestep`: Convective precipitation rate on previous timestep
     * `real`: units = mm s-1
 * `effective_radius_of_stratiform_cloud_graupel_particle`: Effective radius of stratiform cloud graupel particle
-    * `Equivalent CF name`: effective_radius_of_stratiform_cloud_graupel_particles
+    * Equivalent CF name: `effective_radius_of_stratiform_cloud_graupel_particles`
     * `real`: units = um
 * `effective_radius_of_stratiform_cloud_ice_particle`: Effective radius of stratiform cloud ice particle
-    * `Equivalent CF name`: effective_radius_of_stratiform_cloud_ice_particles
+    * Equivalent CF name: `effective_radius_of_stratiform_cloud_ice_particles`
     * `real`: units = um
 * `effective_radius_of_stratiform_cloud_liquid_water_particle`: Effective radius of stratiform cloud liquid water particle
-    * `Equivalent CF name`: effective_radius_of_stratiform_cloud_liquid_water_particles
+    * Equivalent CF name: `effective_radius_of_stratiform_cloud_liquid_water_particles`
     * `real`: units = um
 * `effective_radius_of_stratiform_cloud_rain_particle`: Effective radius of stratiform cloud rain particle
-    * `Equivalent CF name`: effective_radius_of_stratiform_cloud_rain_particles
+    * Equivalent CF name: `effective_radius_of_stratiform_cloud_rain_particles`
     * `real`: units = um
 * `effective_radius_of_stratiform_cloud_snow_particle`: Effective radius of stratiform cloud snow particle
-    * `Equivalent CF name`: effective_radius_of_stratiform_cloud_snow_particles
+    * Equivalent CF name: `effective_radius_of_stratiform_cloud_snow_particles`
     * `real`: units = um
 * `graupel_mixing_ratio_wrt_moist_air`: Graupel mass mixing ratio with respect to moist air
     * `real`: units = kg kg-1
@@ -2207,7 +2207,7 @@ Thresholds represent some value at which the behavior of some process changes, i
 * `albedo_on_previous_timestep_assuming_deep_snow`: Albedo on previous timestep assuming deep snow
     * `real`: units = fraction
 * `area_type`: Area type
-    * `Equivalent CF name`: area_type
+    * Equivalent CF name: `area_type`
     * `real`: units = 1
 * `area_type_from_coupled_process`: Area type from coupled process
     * `real`: units = 1
@@ -2220,10 +2220,10 @@ Thresholds represent some value at which the behavior of some process changes, i
 * `canopy_intercepted_liquid_water`: Canopy intercepted liquid water
     * `real`: units = mm
 * `canopy_temperature`: Canopy temperature
-    * `Equivalent CF name`: canopy_temperature
+    * Equivalent CF name: `canopy_temperature`
     * `real`: units = K
 * `canopy_water_mass_content`: Water mass per unit area in the canopy
-    * `Equivalent CF name`: canopy_water_amount
+    * Equivalent CF name: `canopy_water_amount`
     * `real`: units = kg m-2
 * `cumulative_lwe_thickness_of_convective_precipitation_between_sw_radiation_calls`: Cumulative liquid water equivalent thickness of convective precipitation amount between shortwave radiation calls
     * `real`: units = m
@@ -2236,7 +2236,7 @@ Thresholds represent some value at which the behavior of some process changes, i
 * `deep_soil_temperature`: Deep soil temperature
     * `real`: units = K
 * `density_of_snow_at_surface`: Density of snow accumulated on ground surface
-    * `Equivalent CF name`: surface_snow_density
+    * Equivalent CF name: `surface_snow_density`
     * `real`: units = kg m-3
 * `depth_from_snow_surface_at_bottom_interface`: depth from the top of the snow surface at the bottom of the soil layer
     * `real`: units = m
@@ -2277,7 +2277,7 @@ Thresholds represent some value at which the behavior of some process changes, i
 * `explicit_precipitation_rate_on_previous_timestep`: Explicit precipitation rate on previous timestep
     * `real`: units = mm s-1
 * `fast_soil_pool_mass_content_of_carbon`: Fast soil pool mass content of carbon
-    * `Equivalent CF name`: fast_soil_pool_mass_content_of_carbon
+    * Equivalent CF name: `fast_soil_pool_mass_content_of_carbon`
     * `real`: units = g m-2
 * `fine_root_mass_content`: Fine root mass content
     * `real`: units = g m-2
@@ -2294,20 +2294,20 @@ Thresholds represent some value at which the behavior of some process changes, i
 * `lake_depth`: Lake depth
     * `real`: units = m
 * `land_area_fraction`: Land area fraction
-    * `Equivalent CF name`: land_area_fraction
+    * Equivalent CF name: `land_area_fraction`
     * `real`: units = fraction
 * `land_ice_area_fraction_of_cell_area`: fraction of horizontal area of grid cell that is ice over land
-    * `Equivalent CF name`: land_ice_area_fraction
+    * Equivalent CF name: `land_ice_area_fraction`
     * `real`: units = frac
 * `land_surface_perturbation_variables`: Land surface perturbation variables
     * `character`: units = none
 * `leaf_area_index`: Leaf area index
-    * `Equivalent CF name`: leaf_area_index
+    * Equivalent CF name: `leaf_area_index`
     * `real`: units = 1
 * `leaf_mass_content`: Leaf mass content
     * `real`: units = g m-2
 * `lwe_snowfall_rate`: Liquid water equivalent snowfall rate
-    * `Equivalent CF name`: lwe_snowfall_rate
+    * Equivalent CF name: `lwe_snowfall_rate`
     * `real`: units = mm s-1
 * `lwe_surface_snow`: Liquid water equivalent surface snow
     * `real`: units = mm
@@ -2332,7 +2332,7 @@ Thresholds represent some value at which the behavior of some process changes, i
 * `lwe_thickness_of_snowfall_on_previous_timestep`: Liquid water equivalent thickness of snowfall amount on previous timestep
     * `real`: units = mm
 * `lwe_thickness_of_surface_snow`: Liquid water equivalent thickness of surface snow amount
-    * `Equivalent CF name`: lwe_thickness_of_surface_snow_amount
+    * Equivalent CF name: `lwe_thickness_of_surface_snow_amount`
     * `real`: units = mm
 * `mass_content_of_water_in_top_soil_layer`: mass per unit area of water in top layer of soil
     * `real`: units = kg m-2
@@ -2345,7 +2345,7 @@ Thresholds represent some value at which the behavior of some process changes, i
 * `normalized_soil_wetness_for_lsm`: Normalized soil wetness for land surface model
     * `real`: units = fraction
 * `roughness_length`: surface roughness length
-    * `Equivalent CF name`: surface_roughness_length
+    * Equivalent CF name: `surface_roughness_length`
     * `real`: units = cm
 * `roughness_length_from_wave_model`: surface roughness length from wave model
     * `real`: units = cm
@@ -2360,10 +2360,10 @@ Thresholds represent some value at which the behavior of some process changes, i
 * `sea_ice_area_fraction_of_sea_area_fraction`: Sea ice area fraction of sea area fraction
     * `real`: units = fraction
 * `sea_ice_temperature`: Sea ice temperature
-    * `Equivalent CF name`: sea_ice_temperature
+    * Equivalent CF name: `sea_ice_temperature`
     * `real`: units = K
 * `sea_ice_thickness`: Sea ice thickness
-    * `Equivalent CF name`: sea_ice_thickness
+    * Equivalent CF name: `sea_ice_thickness`
     * `real`: units = m
 * `skin_temperature_at_surface_over_ice`: Skin temperature at surface over (or where) ice
     * `real`: units = K
@@ -2374,7 +2374,7 @@ Thresholds represent some value at which the behavior of some process changes, i
 * `skin_temperature_at_surface_over_snow`: Skin temperature at surface over (or where) snow
     * `real`: units = K
 * `slow_soil_pool_mass_content_of_carbon`: Slow soil pool mass content of carbon
-    * `Equivalent CF name`: slow_soil_pool_mass_content_of_carbon
+    * Equivalent CF name: `slow_soil_pool_mass_content_of_carbon`
     * `real`: units = g m-2
 * `snow_area_fraction_at_surface_over_ice`: Snow area fraction at surface over ice
     * `real`: units = fraction
@@ -2405,7 +2405,7 @@ Thresholds represent some value at which the behavior of some process changes, i
 * `surface_friction_velocity_for_momentum`: Surface friction velocity for momentum
     * `real`: units = m s-1
 * `surface_longwave_emissivity`: Surface longwave emissivity
-    * `Equivalent CF name`: surface_longwave_emissivity
+    * Equivalent CF name: `surface_longwave_emissivity`
     * `real`: units = fraction
 * `surface_longwave_emissivity_over_ice`: Surface longwave emissivity over ice
     * `real`: units = fraction
@@ -2436,19 +2436,19 @@ Thresholds represent some value at which the behavior of some process changes, i
 * `upper_bound_of_max_albedo_assuming_deep_snow`: Upper bound of maximum albedo assuming deep snow
     * `real`: units = fraction
 * `upward_latent_heat_flux_at_surface`: Upward latent heat flux at surface
-    * `Equivalent CF name`: surface_upward_latent_heat_flux
+    * Equivalent CF name: `surface_upward_latent_heat_flux`
     * `real`: units = W m-2
 * `urban_area_fraction_of_cell_area`: fraction of horizontal area of grid cell that is urban
     * `real`: units = frac
 * `vegetation_area_fraction`: Vegetation area fraction
-    * `Equivalent CF name`: vegetation_area_fraction
+    * Equivalent CF name: `vegetation_area_fraction`
     * `real`: units = fraction
 * `vis_albedo_strong_cosz`: albedo for visible radiation with strong dependence on cosine of the zenith angle
     * `real`: units = fraction
 * `vis_albedo_weak_cosz`: albedo for visible radiation with weak dependence on cosine of the zenith angle
     * `real`: units = fraction
 * `volume_fraction_of_condensed_water_in_soil`: Volume fraction of condensed water in soil
-    * `Equivalent CF name`: volume_fraction_of_condensed_water_in_soil
+    * Equivalent CF name: `volume_fraction_of_condensed_water_in_soil`
     * `real`: units = fraction
 * `volume_fraction_of_frozen_soil_moisture_for_lsm`: Volume fraction of frozen soil moisture for land surface model
     * `real`: units = fraction
@@ -2528,7 +2528,7 @@ Thresholds represent some value at which the behavior of some process changes, i
     * `real`: units = m
 ## Tendencies
 * `lagrangian_tendency_of_air_pressure`: Vertical pressure velocity
-    * `Equivalent CF name`: lagrangian_tendency_of_air_pressure
+    * Equivalent CF name: `lagrangian_tendency_of_air_pressure`
     * `real`: units = Pa s-1
 * `process_split_cumulative_tendency_of_air_temperature`: Process split cumulative tendency of air temperature
     * `real`: units = K s-1
@@ -2565,7 +2565,7 @@ Thresholds represent some value at which the behavior of some process changes, i
 * `tendency_of_activated_cloud_condensation_nuclei_from_climatology`: Change of activated cloud condensation nuclei from climatology per unit time
     * `real`: units = kg-1 s-1
 * `tendency_of_air_temperature`: Change in temperature per unit time
-    * `Equivalent CF name`: tendency_of_air_temperature
+    * Equivalent CF name: `tendency_of_air_temperature`
     * `real`: units = K s-1
 * `tendency_of_air_temperature_due_to_integrated_dynamics_through_earths_atmosphere`: Tendency of air temperature due to integrated dynamics through earths atmosphere
     * `real`: units = K s-1
@@ -2574,7 +2574,7 @@ Thresholds represent some value at which the behavior of some process changes, i
 * `tendency_of_air_temperature_due_to_longwave_heating_on_radiation_timestep`: Tendency of air temperature due to longwave heating on radiation timestep
     * `real`: units = K s-1
 * `tendency_of_air_temperature_due_to_model_physics`: Change in air temperature due to model physics per unit time
-    * `Equivalent CF name`: tendency_of_air_temperature_due_to_model_physics
+    * Equivalent CF name: `tendency_of_air_temperature_due_to_model_physics`
     * `real`: units = K s-1
 * `tendency_of_air_temperature_due_to_nonphysics`: Tendency of air temperature due to nonphysics
     * `real`: units = K s-1
@@ -2585,20 +2585,20 @@ Thresholds represent some value at which the behavior of some process changes, i
 * `tendency_of_dry_air_enthalpy_at_constant_pressure`: Change of dry air enthalpy per unit time at constant pressure; d/dt(Cp*T)
     * `real`: units = J kg-1 s-1
 * `tendency_of_eastward_wind`: Change in eastward wind per unit time
-    * `Equivalent CF name`: tendency_of_eastward_wind
+    * Equivalent CF name: `tendency_of_eastward_wind`
     * `real`: units = m s-2
 * `tendency_of_eastward_wind_due_to_model_physics`: Change in eastward wind due to model physics per unit time
-    * `Equivalent CF name`: tendency_of_eastward_wind_due_to_parameterized_physics
+    * Equivalent CF name: `tendency_of_eastward_wind_due_to_parameterized_physics`
     * `real`: units = m s-2
 * `tendency_of_hygroscopic_aerosols_at_surface_adjacent_layer`: Tendency of hygroscopic aerosols at surface adjacent layer
     * `real`: units = kg-1 s-1
 * `tendency_of_nonhygroscopic_ice_nucleating_aerosols_at_surface_adjacent_layer`: Tendency of nonhygroscopic ice nucleating aerosols at surface adjacent layer
     * `real`: units = kg-1 s-1
 * `tendency_of_northward_wind`: Change in northward wind per unit time
-    * `Equivalent CF name`: tendency_of_northward_wind
+    * Equivalent CF name: `tendency_of_northward_wind`
     * `real`: units = m s-2
 * `tendency_of_northward_wind_due_to_model_physics`: Change in northward wind due to model physics per unit time
-    * `Equivalent CF name`: tendency_of_northward_wind_due_to_parameterized_physics
+    * Equivalent CF name: `tendency_of_northward_wind_due_to_parameterized_physics`
     * `real`: units = m s-2
 * `tendency_of_potential_temperature_of_air`: Change in potential temperature per unit time
     * `real`: units = K s-1

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -31,7 +31,7 @@ The following names are too general to be chosen as standard names, but they can
 * `area`: Area
     * `real`: units = m2
 * `area_fraction`: The fraction of an area where some condition applies
-    * Equivalent CF name: area_fraction
+    * `Equivalent CF name`: area_fraction
     * `real`: units = 1
 * `binary_mask`: A field consisting of either 0 or 1 at every point
     * `integer`: units = 1
@@ -148,15 +148,15 @@ These names are used as bases for other names, but may also be considered standa
 * `air_pressure_thickness`: The difference in air pressure between two vertical layers
     * `real`: units = Pa
 * `air_temperature`: The temperature of air
-    * Equivalent CF name: air_temperature
+    * `Equivalent CF name`: air_temperature
     * `real`: units = K
 * `albedo`: The fraction of incident radiation reflected by a surface
     * `real`: units = 1
 * `atmosphere_heat_diffusivity`: Atmosphere heat diffusivity
-    * Equivalent CF name: atmosphere_heat_diffusivity
+    * `Equivalent CF name`: atmosphere_heat_diffusivity
     * `real`: units = m2 s-1
 * `cloud_area_fraction`: Fraction of an area (usually within a grid cell) containing cloud
-    * Equivalent CF name: cloud_area_fraction
+    * `Equivalent CF name`: cloud_area_fraction
     * `real`: units = fraction
 * `cloud_condensate`: Amount of condensed water in cloud
 * `cloud_ice_water`: Cloud particles consisting of solid water (ice)
@@ -172,7 +172,7 @@ These names are used as bases for other names, but may also be considered standa
 * `diffuse_vis_albedo`: Albedo of diffuse incident visible radiation
     * `real`: units = 1
 * `dimensionless_exner_function`: Dimensionless formulation of the Exner function with respect to 1000 hPa
-    * Equivalent CF name: dimensionless_exner_function
+    * `Equivalent CF name`: dimensionless_exner_function
     * `real`: units = 1
 * `direct_nir_albedo`: Albedo of direct incident near-infrared radiation
     * `real`: units = 1
@@ -197,10 +197,10 @@ These names are used as bases for other names, but may also be considered standa
 * `friction_velocity`: A measure of shear stress within a fluid layer with units of distance per time
     * `real`: units = m s-1
 * `geopotential`: Gravitational potential energy of a unit mass relative to sea level
-    * Equivalent CF name: geopotential
+    * `Equivalent CF name`: geopotential
     * `real`: units = m2 s-2
 * `geopotential_height`: Geopotential divided by the gravitational constant
-    * Equivalent CF name: geopotential_height
+    * `Equivalent CF name`: geopotential_height
     * `real`: units = m
 * `graupel`: Precipitation consisting of heavily rimed ice crystals
 * `gravitational_acceleration`: Gravitational acceleration
@@ -222,7 +222,7 @@ These names are used as bases for other names, but may also be considered standa
 * `random_number_seed`: Random number seed
     * `integer`: units = 1
 * `reference_pressure`: Some pressure value for comparison to or calculation of other values
-    * Equivalent CF name: reference_pressure
+    * `Equivalent CF name`: reference_pressure
     * `real`: units = Pa
 * `relative_humidity`: Ratio of the vapor pressure to the saturation vapor pressure (for liquid water unless otherwise specified)
     * `real`: units = fraction
@@ -237,15 +237,15 @@ These names are used as bases for other names, but may also be considered standa
     * `real`: units = fraction
 * `soil_moisture`: Water contained within a soil layer
 * `soil_temperature`: Temperature of a soil layer
-    * Equivalent CF name: soil_temperature
+    * `Equivalent CF name`: soil_temperature
     * `real`: units = K
 * `solar_declination_angle`: The angle between the equator and Earth's orbital plane with the Sun
     * `real`: units = degrees
 * `solar_zenith_angle`: The angle between the direction to the sun and the local zenith (vertical direction)
-    * Equivalent CF name: solar_zenith_angle
+    * `Equivalent CF name`: solar_zenith_angle
     * `real`: units = degrees
 * `surface_skin_temperature`: The temperature of the topmost layer of the surface
-    * Equivalent CF name: surface_skin_temperature
+    * `Equivalent CF name`: surface_skin_temperature
     * `real`: units = K
 * `temperature`: Temperature
     * `real`: units = K
@@ -262,12 +262,12 @@ These names are used as bases for other names, but may also be considered standa
 * `virtual_potential_temperature`: The theoretical potential temperature of dry air that would have the same density as moist air
     * `real`: units = K
 * `virtual_temperature`: The theoretical temperature of dry air that would have the same density as moist air
-    * Equivalent CF name: virtual_temperature
+    * `Equivalent CF name`: virtual_temperature
     * `real`: units = K
 * `water_vapor`: Water in the gaseous phase
 * `wind`: Movement of air with a net displacement
 * `wind_speed`: Speed of moving air
-    * Equivalent CF name: wind_speed
+    * `Equivalent CF name`: wind_speed
     * `real`: units = m s-1
 * `wind_stress`: Shear stress exerted by wind parallel to the surface
     * `real`: units = Pa
@@ -338,7 +338,7 @@ Constant parameters that should be identical across a full modeling system
 ## Coordinates
 Parameters defining or relating to the coordinate system of the model
 * `cell_area`: horizontal area of a grid cell
-    * Equivalent CF name: cell_area
+    * `Equivalent CF name`: cell_area
     * `real`: units = m2
 * `cell_scaling_factor`: Cell scaling factor
     * `real`: units = 1
@@ -347,22 +347,22 @@ Parameters defining or relating to the coordinate system of the model
 * `cosine_of_latitude`: Cosine of latitude
     * `real`: units = 1
 * `height_above_mean_sea_level`: Height above mean sea level
-    * Equivalent CF name: height_above_mean_sea_level
+    * `Equivalent CF name`: height_above_mean_sea_level
     * `real`: units = m
 * `height_above_mean_sea_level_at_surface`: Height above mean sea level at local surface
     * `real`: units = m
 * `latitude`: Latitude
-    * Equivalent CF name: latitude
+    * `Equivalent CF name`: latitude
     * `real`: units = degree_north
 * `longitude`: Longitude
-    * Equivalent CF name: longitude
+    * `Equivalent CF name`: longitude
     * `real`: units = degree_east
 * `sigma_pressure_hybrid_coordinate_a_coefficient`: Sigma pressure hybrid coordinate a coefficient
     * `real`: units = Pa
 * `sigma_pressure_hybrid_coordinate_b_coefficient`: Sigma pressure hybrid coordinate b coefficient
     * `real`: units = 1
 * `sigma_pressure_hybrid_vertical_coordinate`: Sigma pressure hybrid vertical coordinate
-    * Equivalent CF name: atmosphere_hybrid_sigma_pressure_coordinate
+    * `Equivalent CF name`: atmosphere_hybrid_sigma_pressure_coordinate
     * `real`: units = 1
 * `sine_of_latitude`: Sine of latitude
     * `real`: units = 1
@@ -396,22 +396,22 @@ Variables defining or relating to timing, dates, calendar, and related concepts
     * `real`: units = s
 ## Atmospheric properties
 * `air_pressure`: Midpoint air pressure
-    * Equivalent CF name: air_pressure
+    * `Equivalent CF name`: air_pressure
     * `real`: units = Pa
 * `air_pressure_at_interfaces`: Air pressure at interfaces
     * `real`: units = Pa
 * `air_pressure_at_lowest_model_interface`: Air pressure at lowest model interface
     * `real`: units = Pa
 * `air_pressure_at_sea_level`: Air pressure at sea level
-    * Equivalent CF name: air_pressure_at_mean_sea_level
+    * `Equivalent CF name`: air_pressure_at_mean_sea_level
     * `real`: units = Pa
 * `air_pressure_at_surface`: Air pressure at local surface
-    * Equivalent CF name: surface_air_pressure
+    * `Equivalent CF name`: surface_air_pressure
     * `real`: units = Pa
 * `air_pressure_at_surface_adjacent_layer`: Air pressure at surface adjacent layer
     * `real`: units = Pa
 * `air_pressure_at_top_of_atmosphere_model`: Air pressure at top of atmosphere model
-    * Equivalent CF name: air_pressure_at_top_of_atmosphere_model
+    * `Equivalent CF name`: air_pressure_at_top_of_atmosphere_model
     * `real`: units = Pa
 * `air_pressure_extended_up_by_1`: Air pressure extended up by 1
     * `real`: units = Pa
@@ -442,7 +442,7 @@ Variables defining or relating to timing, dates, calendar, and related concepts
 * `air_temperature_two_timesteps_back`: Air temperature two timesteps back
     * `real`: units = K
 * `atmosphere_boundary_layer_thickness`: Atmosphere boundary layer thickness
-    * Equivalent CF name: atmosphere_boundary_layer_thickness
+    * `Equivalent CF name`: atmosphere_boundary_layer_thickness
     * `real`: units = m
 * `atmosphere_heat_diffusivity_due_to_background`: Atmosphere heat diffusivity due to background
     * `real`: units = m2 s-1
@@ -471,10 +471,10 @@ Variables defining or relating to timing, dates, calendar, and related concepts
 * `dimensionless_exner_function_wrt_surface_pressure`: Dimensionless exner function with respect to surface pressure, (p/ps)^(Rd/cp)
     * `real`: units = 1
 * `dry_static_energy`: Dry static energy content of atmosphere layer
-    * Equivalent CF name: dry_static_energy_content_of_atmosphere_layer
+    * `Equivalent CF name`: dry_static_energy_content_of_atmosphere_layer
     * `real`: units = J kg-1
 * `eastward_wind`: Wind vector component, positive when directed eastward
-    * Equivalent CF name: eastward_wind
+    * `Equivalent CF name`: eastward_wind
     * `real`: units = m s-1
 * `eastward_wind_at_10m`: Wind vector component at 10 meters above surface, positive when directed eastward
     * `real`: units = m s-1
@@ -495,12 +495,12 @@ Variables defining or relating to timing, dates, calendar, and related concepts
 * `gravitational_acceleration`: Gravitational acceleration
     * `real`: units = m s-2
 * `horizontal_divergence_of_air`: The horizontal divergence of the 2-D vector wind field
-    * Equivalent CF name: divergence_of_wind
+    * `Equivalent CF name`: divergence_of_wind
     * `real`: units = s-1
 * `horizontal_streamfunction_of_air`: Scalar function describing the streamlines of the horizontal wind
     * `real`: units = m2 s-1
 * `horizontal_velocity_potential_of_air`: Scalar potential of the horizontal wind
-    * Equivalent CF name: atmosphere_horizontal_velocity_potential
+    * `Equivalent CF name`: atmosphere_horizontal_velocity_potential
     * `real`: units = m2 s-1
 * `is_initialized_physics_grid`: Flag to indicate if physics grid is initialized
     * `logical`: units = flag
@@ -533,10 +533,10 @@ Variables defining or relating to timing, dates, calendar, and related concepts
 * `nonadvected_tke_multiplied_by_2`: Non-advected turbulent kinetic energy multiplied by 2
     * `real`: units = m2 s-2
 * `nonconvective_cloud_area_fraction_in_atmosphere_layer`: cloud area fraction in atmosphere layer excluding clouds produced by the convective schemes
-    * Equivalent CF name: stratiform_cloud_area_fraction_in_atmosphere_layer
+    * `Equivalent CF name`: stratiform_cloud_area_fraction_in_atmosphere_layer
     * `real`: units = fraction
 * `northward_wind`: Wind vector component, positive when directed northward
-    * Equivalent CF name: northward_wind
+    * `Equivalent CF name`: northward_wind
     * `real`: units = m s-1
 * `northward_wind_at_10m`: Wind vector component at 10 meters above surface, positive when directed northward
     * `real`: units = m s-1
@@ -545,7 +545,7 @@ Variables defining or relating to timing, dates, calendar, and related concepts
 * `physics_state_due_to_dynamics`: Physics state due to dynamics
     * `ddt`: units = none
 * `potential_temperature_of_air`: air potential temperature
-    * Equivalent CF name: air_potential_temperature
+    * `Equivalent CF name`: air_potential_temperature
     * `real`: units = K
 * `potential_temperature_of_air_at_2m`: Potential temperature of air at 2m
     * `real`: units = K
@@ -568,7 +568,7 @@ Variables defining or relating to timing, dates, calendar, and related concepts
 * `reference_pressure_in_atmosphere_layer_normalized_by_surface_reference_pressure`: Reference pressure in atmosphere layer normalized by surface reference pressure
     * `real`: units = 1
 * `relative_humidity`: Relative humidity
-    * Equivalent CF name: relative_humidity
+    * `Equivalent CF name`: relative_humidity
     * `real`: units = fraction
 * `relative_humidity_at_2m`: Relative humidity at 2m
     * `real`: units = fraction
@@ -587,10 +587,10 @@ Variables defining or relating to timing, dates, calendar, and related concepts
 * `timestep_for_physics`: Timestep for physics
     * `integer`: units = s
 * `upward_absolute_vorticity_of_air`: The upward (kth) component of the curl of the vector wind field
-    * Equivalent CF name: atmosphere_upward_absolute_vorticity
+    * `Equivalent CF name`: atmosphere_upward_absolute_vorticity
     * `real`: units = s-1
 * `upward_heat_flux_in_air_at_surface`: Upward heat flux in air at surface
-    * Equivalent CF name: surface_upward_heat_flux_in_air
+    * `Equivalent CF name`: surface_upward_heat_flux_in_air
     * `real`: units = W m-2
 * `us_standard_air_pressure_at_sea_level`: US Standard Atmospheric pressure at sea level
     * `real`: units = Pa
@@ -619,7 +619,7 @@ Variables defining or relating to timing, dates, calendar, and related concepts
 * `wind_speed_at_surface`: Scalar wind speed closest to surface
     * `real`: units = m s-1
 * `x_wind`: Horizontal wind in a direction perpendicular to y_wind
-    * Equivalent CF name: x_wind
+    * `Equivalent CF name`: x_wind
     * `real`: units = m s-1
 * `x_wind_at_surface_adjacent_layer`: X wind at surface adjacent layer
     * `real`: units = m s-1
@@ -628,7 +628,7 @@ Variables defining or relating to timing, dates, calendar, and related concepts
 * `x_wind_of_new_state_at_surface_adjacent_layer`: X wind of new state at surface adjacent layer
     * `real`: units = m s-1
 * `y_wind`: Horizontal wind in a direction perpendicular to x_wind
-    * Equivalent CF name: y_wind
+    * `Equivalent CF name`: y_wind
     * `real`: units = m s-1
 * `y_wind_at_surface_adjacent_layer`: Y wind at surface adjacent layer
     * `real`: units = m s-1
@@ -652,29 +652,29 @@ Variables defining or relating to timing, dates, calendar, and related concepts
 * `molecular_sublayer_thickness_in_sea_water`: Molecular sublayer thickness in sea water
     * `real`: units = m
 * `ocean_mixed_layer_thickness`: Ocean mixed layer thickness
-    * Equivalent CF name: ocean_mixed_layer_thickness
+    * `Equivalent CF name`: ocean_mixed_layer_thickness
     * `real`: units = m
 * `reference_sea_surface_temperature`: Foundation/reference temperature for calculating diurnal ocean temperature changes
     * `real`: units = K
 * `sea_surface_temperature`: Sea surface temperature
-    * Equivalent CF name: sea_surface_temperature
+    * `Equivalent CF name`: sea_surface_temperature
     * `real`: units = K
 * `sea_water_absolute_salinity`: The absolute salinity of sea water
-    * Equivalent CF name: sea_water_absolute_salinity
+    * `Equivalent CF name`: sea_water_absolute_salinity
     * `real`: units = g kg-1
 * `sea_water_depth`: The depth of the ocean floor below the surface of the sea
-    * Equivalent CF name: sea_floor_depth_below_geoid
+    * `Equivalent CF name`: sea_floor_depth_below_geoid
     * `real`: units = m
 * `sea_water_potential_temperature`: sea water potential temperature
-    * Equivalent CF name: sea_water_potential_temperature
+    * `Equivalent CF name`: sea_water_potential_temperature
     * `real`: units = K
 * `sea_water_practical_salinity`: The practical salinity of sea water
-    * Equivalent CF name: sea_water_practical_salinity
+    * `Equivalent CF name`: sea_water_practical_salinity
     * `real`: units = PSU
 * `sea_water_salinity_in_diurnal_thermocline`: Sea water salinity in diurnal thermocline
     * `real`: units = ppt m
 * `sea_water_temperature`: The temperature of sea water
-    * Equivalent CF name: sea_water_temperature
+    * `Equivalent CF name`: sea_water_temperature
     * `real`: units = K
 * `x_current_in_diurnal_thermocline`: X current in diurnal thermocline
     * `real`: units = m2 s-1
@@ -703,13 +703,13 @@ Tracers are numerically zero-mass particles advected in fluid flow, typically re
 * `derivative_of_ln_water_vapor_partial_pressure_assuming_saturation_wrt_air_temperature_at_top_interfaces`: derivative of the natural logarithm of water vapor partial pressure at saturation with respect to air temperature at all interfaces excluding surface
     * `real`: units = K-1
 * `mole_fraction_of_co2_in_air`: Mole fraction of co2 in air
-    * Equivalent CF name: mole_fraction_of_carbon_dioxide_in_air
+    * `Equivalent CF name`: mole_fraction_of_carbon_dioxide_in_air
     * `real`: units = mol mol-1
 * `mole_fraction_of_ozone_in_air`: Mole fraction of ozone in air
-    * Equivalent CF name: mole_fraction_of_ozone_in_air
+    * `Equivalent CF name`: mole_fraction_of_ozone_in_air
     * `real`: units = mol mol-1
 * `mole_fraction_of_water_vapor`: Mole fraction of water vapor
-    * Equivalent CF name: mole_fraction_of_water_vapor_in_air
+    * `Equivalent CF name`: mole_fraction_of_water_vapor_in_air
     * `real`: units = mol mol-1
 * `number_density_of_anomalous_oxygen`: Number density of energetic, non-thermal atomic oxygen as defined in MSIS
     * `real`: units = m-3
@@ -790,12 +790,12 @@ Tracers are numerically zero-mass particles advected in fluid flow, typically re
 * `volume_mixing_ratio_of_so2`: Sulfur dioxide volume mixing ratio
     * `real`: units = mol mol-1
 * `water_vapor_mixing_ratio_wrt_dry_air`: Ratio of the mass of water vapor to the mass of dry air
-    * Equivalent CF name: humidity_mixing_ratio
+    * `Equivalent CF name`: humidity_mixing_ratio
     * `real`: units = kg kg-1
 * `water_vapor_mixing_ratio_wrt_dry_air_at_top_interfaces`: Ratio of the mass of water vapor to the mass of dry air at all interfaces excluding surface
     * `real`: units = kg kg-1
 * `water_vapor_mixing_ratio_wrt_moist_air`: Ratio of the mass of water vapor to the mass of moist air
-    * Equivalent CF name: specific_humidity
+    * `Equivalent CF name`: specific_humidity
     * `real`: units = kg kg-1
 * `water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water`: Ratio of the mass of water vapor to the mass of moist air and hydrometeors
     * `real`: units = kg kg-1
@@ -815,7 +815,7 @@ Tracers are numerically zero-mass particles advected in fluid flow, typically re
 * `cloud_condensed_water_mixing_ratio_wrt_moist_air_at_surface_over_land`: Cloud condensed water mass mixing ratio with respect to moist air at surface over land
     * `real`: units = kg kg-1
 * `cloud_ice_mixing_ratio_wrt_dry_air`: Ratio of the mass of cloud ice to the mass of dry air
-    * Equivalent CF name: cloud_ice_mixing_ratio
+    * `Equivalent CF name`: cloud_ice_mixing_ratio
     * `real`: units = kg kg-1
 * `cloud_ice_mixing_ratio_wrt_dry_air_at_top_interfaces`: Ratio of the mass of cloud ice to the mass of dry air at all interfaces excluding surface
     * `real`: units = kg kg-1
@@ -828,7 +828,7 @@ Tracers are numerically zero-mass particles advected in fluid flow, typically re
 * `cloud_ice_mixing_ratio_wrt_moist_air_of_new_state`: Cloud ice mass mixing ratio with respect to moist air of new state
     * `real`: units = kg kg-1
 * `cloud_liquid_water_mixing_ratio_wrt_dry_air`: Ratio of the mass of cloud liquid water to the mass of dry air
-    * Equivalent CF name: cloud_liquid_water_mixing_ratio
+    * `Equivalent CF name`: cloud_liquid_water_mixing_ratio
     * `real`: units = kg kg-1
 * `cloud_liquid_water_mixing_ratio_wrt_dry_air_at_top_interfaces`: Ratio of the mass of cloud liquid water to the mass of dry air at all interfaces excluding surface
     * `real`: units = kg kg-1
@@ -845,7 +845,7 @@ Tracers are numerically zero-mass particles advected in fluid flow, typically re
 * `cloud_liquid_water_mixing_ratio_wrt_moist_air_of_new_state`: Cloud liquid water mass mixing ratio with respect to moist air of new state
     * `real`: units = kg kg-1
 * `convective_cloud_area_fraction`: Convective cloud area fraction
-    * Equivalent CF name: convective_cloud_area_fraction
+    * `Equivalent CF name`: convective_cloud_area_fraction
     * `real`: units = fraction
 * `convective_cloud_condensate_after_rainout`: Convective cloud condensate after rainout
     * `real`: units = kg kg-1
@@ -854,19 +854,19 @@ Tracers are numerically zero-mass particles advected in fluid flow, typically re
 * `convective_precipitation_rate_on_previous_timestep`: Convective precipitation rate on previous timestep
     * `real`: units = mm s-1
 * `effective_radius_of_stratiform_cloud_graupel_particle`: Effective radius of stratiform cloud graupel particle
-    * Equivalent CF name: effective_radius_of_stratiform_cloud_graupel_particles
+    * `Equivalent CF name`: effective_radius_of_stratiform_cloud_graupel_particles
     * `real`: units = um
 * `effective_radius_of_stratiform_cloud_ice_particle`: Effective radius of stratiform cloud ice particle
-    * Equivalent CF name: effective_radius_of_stratiform_cloud_ice_particles
+    * `Equivalent CF name`: effective_radius_of_stratiform_cloud_ice_particles
     * `real`: units = um
 * `effective_radius_of_stratiform_cloud_liquid_water_particle`: Effective radius of stratiform cloud liquid water particle
-    * Equivalent CF name: effective_radius_of_stratiform_cloud_liquid_water_particles
+    * `Equivalent CF name`: effective_radius_of_stratiform_cloud_liquid_water_particles
     * `real`: units = um
 * `effective_radius_of_stratiform_cloud_rain_particle`: Effective radius of stratiform cloud rain particle
-    * Equivalent CF name: effective_radius_of_stratiform_cloud_rain_particles
+    * `Equivalent CF name`: effective_radius_of_stratiform_cloud_rain_particles
     * `real`: units = um
 * `effective_radius_of_stratiform_cloud_snow_particle`: Effective radius of stratiform cloud snow particle
-    * Equivalent CF name: effective_radius_of_stratiform_cloud_snow_particles
+    * `Equivalent CF name`: effective_radius_of_stratiform_cloud_snow_particles
     * `real`: units = um
 * `graupel_mixing_ratio_wrt_moist_air`: Graupel mass mixing ratio with respect to moist air
     * `real`: units = kg kg-1
@@ -2207,7 +2207,7 @@ Thresholds represent some value at which the behavior of some process changes, i
 * `albedo_on_previous_timestep_assuming_deep_snow`: Albedo on previous timestep assuming deep snow
     * `real`: units = fraction
 * `area_type`: Area type
-    * Equivalent CF name: area_type
+    * `Equivalent CF name`: area_type
     * `real`: units = 1
 * `area_type_from_coupled_process`: Area type from coupled process
     * `real`: units = 1
@@ -2220,10 +2220,10 @@ Thresholds represent some value at which the behavior of some process changes, i
 * `canopy_intercepted_liquid_water`: Canopy intercepted liquid water
     * `real`: units = mm
 * `canopy_temperature`: Canopy temperature
-    * Equivalent CF name: canopy_temperature
+    * `Equivalent CF name`: canopy_temperature
     * `real`: units = K
 * `canopy_water_mass_content`: Water mass per unit area in the canopy
-    * Equivalent CF name: canopy_water_amount
+    * `Equivalent CF name`: canopy_water_amount
     * `real`: units = kg m-2
 * `cumulative_lwe_thickness_of_convective_precipitation_between_sw_radiation_calls`: Cumulative liquid water equivalent thickness of convective precipitation amount between shortwave radiation calls
     * `real`: units = m
@@ -2236,7 +2236,7 @@ Thresholds represent some value at which the behavior of some process changes, i
 * `deep_soil_temperature`: Deep soil temperature
     * `real`: units = K
 * `density_of_snow_at_surface`: Density of snow accumulated on ground surface
-    * Equivalent CF name: surface_snow_density
+    * `Equivalent CF name`: surface_snow_density
     * `real`: units = kg m-3
 * `depth_from_snow_surface_at_bottom_interface`: depth from the top of the snow surface at the bottom of the soil layer
     * `real`: units = m
@@ -2277,7 +2277,7 @@ Thresholds represent some value at which the behavior of some process changes, i
 * `explicit_precipitation_rate_on_previous_timestep`: Explicit precipitation rate on previous timestep
     * `real`: units = mm s-1
 * `fast_soil_pool_mass_content_of_carbon`: Fast soil pool mass content of carbon
-    * Equivalent CF name: fast_soil_pool_mass_content_of_carbon
+    * `Equivalent CF name`: fast_soil_pool_mass_content_of_carbon
     * `real`: units = g m-2
 * `fine_root_mass_content`: Fine root mass content
     * `real`: units = g m-2
@@ -2294,20 +2294,20 @@ Thresholds represent some value at which the behavior of some process changes, i
 * `lake_depth`: Lake depth
     * `real`: units = m
 * `land_area_fraction`: Land area fraction
-    * Equivalent CF name: land_area_fraction
+    * `Equivalent CF name`: land_area_fraction
     * `real`: units = fraction
 * `land_ice_area_fraction_of_cell_area`: fraction of horizontal area of grid cell that is ice over land
-    * Equivalent CF name: land_ice_area_fraction
+    * `Equivalent CF name`: land_ice_area_fraction
     * `real`: units = frac
 * `land_surface_perturbation_variables`: Land surface perturbation variables
     * `character`: units = none
 * `leaf_area_index`: Leaf area index
-    * Equivalent CF name: leaf_area_index
+    * `Equivalent CF name`: leaf_area_index
     * `real`: units = 1
 * `leaf_mass_content`: Leaf mass content
     * `real`: units = g m-2
 * `lwe_snowfall_rate`: Liquid water equivalent snowfall rate
-    * Equivalent CF name: lwe_snowfall_rate
+    * `Equivalent CF name`: lwe_snowfall_rate
     * `real`: units = mm s-1
 * `lwe_surface_snow`: Liquid water equivalent surface snow
     * `real`: units = mm
@@ -2332,7 +2332,7 @@ Thresholds represent some value at which the behavior of some process changes, i
 * `lwe_thickness_of_snowfall_on_previous_timestep`: Liquid water equivalent thickness of snowfall amount on previous timestep
     * `real`: units = mm
 * `lwe_thickness_of_surface_snow`: Liquid water equivalent thickness of surface snow amount
-    * Equivalent CF name: lwe_thickness_of_surface_snow_amount
+    * `Equivalent CF name`: lwe_thickness_of_surface_snow_amount
     * `real`: units = mm
 * `mass_content_of_water_in_top_soil_layer`: mass per unit area of water in top layer of soil
     * `real`: units = kg m-2
@@ -2345,7 +2345,7 @@ Thresholds represent some value at which the behavior of some process changes, i
 * `normalized_soil_wetness_for_lsm`: Normalized soil wetness for land surface model
     * `real`: units = fraction
 * `roughness_length`: surface roughness length
-    * Equivalent CF name: surface_roughness_length
+    * `Equivalent CF name`: surface_roughness_length
     * `real`: units = cm
 * `roughness_length_from_wave_model`: surface roughness length from wave model
     * `real`: units = cm
@@ -2360,10 +2360,10 @@ Thresholds represent some value at which the behavior of some process changes, i
 * `sea_ice_area_fraction_of_sea_area_fraction`: Sea ice area fraction of sea area fraction
     * `real`: units = fraction
 * `sea_ice_temperature`: Sea ice temperature
-    * Equivalent CF name: sea_ice_temperature
+    * `Equivalent CF name`: sea_ice_temperature
     * `real`: units = K
 * `sea_ice_thickness`: Sea ice thickness
-    * Equivalent CF name: sea_ice_thickness
+    * `Equivalent CF name`: sea_ice_thickness
     * `real`: units = m
 * `skin_temperature_at_surface_over_ice`: Skin temperature at surface over (or where) ice
     * `real`: units = K
@@ -2374,7 +2374,7 @@ Thresholds represent some value at which the behavior of some process changes, i
 * `skin_temperature_at_surface_over_snow`: Skin temperature at surface over (or where) snow
     * `real`: units = K
 * `slow_soil_pool_mass_content_of_carbon`: Slow soil pool mass content of carbon
-    * Equivalent CF name: slow_soil_pool_mass_content_of_carbon
+    * `Equivalent CF name`: slow_soil_pool_mass_content_of_carbon
     * `real`: units = g m-2
 * `snow_area_fraction_at_surface_over_ice`: Snow area fraction at surface over ice
     * `real`: units = fraction
@@ -2405,7 +2405,7 @@ Thresholds represent some value at which the behavior of some process changes, i
 * `surface_friction_velocity_for_momentum`: Surface friction velocity for momentum
     * `real`: units = m s-1
 * `surface_longwave_emissivity`: Surface longwave emissivity
-    * Equivalent CF name: surface_longwave_emissivity
+    * `Equivalent CF name`: surface_longwave_emissivity
     * `real`: units = fraction
 * `surface_longwave_emissivity_over_ice`: Surface longwave emissivity over ice
     * `real`: units = fraction
@@ -2436,19 +2436,19 @@ Thresholds represent some value at which the behavior of some process changes, i
 * `upper_bound_of_max_albedo_assuming_deep_snow`: Upper bound of maximum albedo assuming deep snow
     * `real`: units = fraction
 * `upward_latent_heat_flux_at_surface`: Upward latent heat flux at surface
-    * Equivalent CF name: surface_upward_latent_heat_flux
+    * `Equivalent CF name`: surface_upward_latent_heat_flux
     * `real`: units = W m-2
 * `urban_area_fraction_of_cell_area`: fraction of horizontal area of grid cell that is urban
     * `real`: units = frac
 * `vegetation_area_fraction`: Vegetation area fraction
-    * Equivalent CF name: vegetation_area_fraction
+    * `Equivalent CF name`: vegetation_area_fraction
     * `real`: units = fraction
 * `vis_albedo_strong_cosz`: albedo for visible radiation with strong dependence on cosine of the zenith angle
     * `real`: units = fraction
 * `vis_albedo_weak_cosz`: albedo for visible radiation with weak dependence on cosine of the zenith angle
     * `real`: units = fraction
 * `volume_fraction_of_condensed_water_in_soil`: Volume fraction of condensed water in soil
-    * Equivalent CF name: volume_fraction_of_condensed_water_in_soil
+    * `Equivalent CF name`: volume_fraction_of_condensed_water_in_soil
     * `real`: units = fraction
 * `volume_fraction_of_frozen_soil_moisture_for_lsm`: Volume fraction of frozen soil moisture for land surface model
     * `real`: units = fraction
@@ -2528,7 +2528,7 @@ Thresholds represent some value at which the behavior of some process changes, i
     * `real`: units = m
 ## Tendencies
 * `lagrangian_tendency_of_air_pressure`: Vertical pressure velocity
-    * Equivalent CF name: lagrangian_tendency_of_air_pressure
+    * `Equivalent CF name`: lagrangian_tendency_of_air_pressure
     * `real`: units = Pa s-1
 * `process_split_cumulative_tendency_of_air_temperature`: Process split cumulative tendency of air temperature
     * `real`: units = K s-1
@@ -2565,7 +2565,7 @@ Thresholds represent some value at which the behavior of some process changes, i
 * `tendency_of_activated_cloud_condensation_nuclei_from_climatology`: Change of activated cloud condensation nuclei from climatology per unit time
     * `real`: units = kg-1 s-1
 * `tendency_of_air_temperature`: Change in temperature per unit time
-    * Equivalent CF name: tendency_of_air_temperature
+    * `Equivalent CF name`: tendency_of_air_temperature
     * `real`: units = K s-1
 * `tendency_of_air_temperature_due_to_integrated_dynamics_through_earths_atmosphere`: Tendency of air temperature due to integrated dynamics through earths atmosphere
     * `real`: units = K s-1
@@ -2574,7 +2574,7 @@ Thresholds represent some value at which the behavior of some process changes, i
 * `tendency_of_air_temperature_due_to_longwave_heating_on_radiation_timestep`: Tendency of air temperature due to longwave heating on radiation timestep
     * `real`: units = K s-1
 * `tendency_of_air_temperature_due_to_model_physics`: Change in air temperature due to model physics per unit time
-    * Equivalent CF name: tendency_of_air_temperature_due_to_model_physics
+    * `Equivalent CF name`: tendency_of_air_temperature_due_to_model_physics
     * `real`: units = K s-1
 * `tendency_of_air_temperature_due_to_nonphysics`: Tendency of air temperature due to nonphysics
     * `real`: units = K s-1
@@ -2585,20 +2585,20 @@ Thresholds represent some value at which the behavior of some process changes, i
 * `tendency_of_dry_air_enthalpy_at_constant_pressure`: Change of dry air enthalpy per unit time at constant pressure; d/dt(Cp*T)
     * `real`: units = J kg-1 s-1
 * `tendency_of_eastward_wind`: Change in eastward wind per unit time
-    * Equivalent CF name: tendency_of_eastward_wind
+    * `Equivalent CF name`: tendency_of_eastward_wind
     * `real`: units = m s-2
 * `tendency_of_eastward_wind_due_to_model_physics`: Change in eastward wind due to model physics per unit time
-    * Equivalent CF name: tendency_of_eastward_wind_due_to_parameterized_physics
+    * `Equivalent CF name`: tendency_of_eastward_wind_due_to_parameterized_physics
     * `real`: units = m s-2
 * `tendency_of_hygroscopic_aerosols_at_surface_adjacent_layer`: Tendency of hygroscopic aerosols at surface adjacent layer
     * `real`: units = kg-1 s-1
 * `tendency_of_nonhygroscopic_ice_nucleating_aerosols_at_surface_adjacent_layer`: Tendency of nonhygroscopic ice nucleating aerosols at surface adjacent layer
     * `real`: units = kg-1 s-1
 * `tendency_of_northward_wind`: Change in northward wind per unit time
-    * Equivalent CF name: tendency_of_northward_wind
+    * `Equivalent CF name`: tendency_of_northward_wind
     * `real`: units = m s-2
 * `tendency_of_northward_wind_due_to_model_physics`: Change in northward wind due to model physics per unit time
-    * Equivalent CF name: tendency_of_northward_wind_due_to_parameterized_physics
+    * `Equivalent CF name`: tendency_of_northward_wind_due_to_parameterized_physics
     * `real`: units = m s-2
 * `tendency_of_potential_temperature_of_air`: Change in potential temperature per unit time
     * `real`: units = K s-1

--- a/Metadata-standard-names.yaml
+++ b/Metadata-standard-names.yaml
@@ -14,6 +14,7 @@ section:
       type: real
       units: m2
     - name: area_fraction
+      cfname: area_fraction
       description: The fraction of an area where some condition applies
       type: real
       units: 1
@@ -259,6 +260,7 @@ section:
       type: real
       units: Pa
     - name: air_temperature
+      cfname: air_temperature
       description: The temperature of air
       type: real
       units: K
@@ -267,6 +269,7 @@ section:
       type: real
       units: 1
     - name: atmosphere_heat_diffusivity
+      cfname: atmosphere_heat_diffusivity
       description: Atmosphere heat diffusivity
       type: real
       units: m2 s-1
@@ -668,6 +671,7 @@ section:
     type: real
     units: 1
   - name: sigma_pressure_hybrid_vertical_coordinate
+    cfname: atmosphere_hybrid_sigma_pressure_coordinate
     description: Sigma pressure hybrid vertical coordinate
     type: real
     units: 1
@@ -742,6 +746,7 @@ section:
   comment: null
   standard_names:
   - name: air_pressure
+    cfname: air_pressure
     description: Midpoint air pressure
     type: real
     units: Pa
@@ -754,10 +759,12 @@ section:
     type: real
     units: Pa
   - name: air_pressure_at_sea_level
+    cfname: air_pressure_at_mean_sea_level
     description: Air pressure at sea level
     type: real
     units: Pa
   - name: air_pressure_at_surface
+    cfname: surface_air_pressure
     description: Air pressure at local surface
     type: real
     units: Pa
@@ -766,6 +773,7 @@ section:
     type: real
     units: Pa
   - name: air_pressure_at_top_of_atmosphere_model
+    cfname: air_pressure_at_top_of_atmosphere_model
     description: Air pressure at top of atmosphere model
     type: real
     units: Pa
@@ -826,6 +834,7 @@ section:
     type: real
     units: K
   - name: atmosphere_boundary_layer_thickness
+    cfname: atmosphere_boundary_layer_thickness
     description: Atmosphere boundary layer thickness
     type: real
     units: m
@@ -948,6 +957,7 @@ section:
     type: real
     units: m2 s-1
   - name: horizontal_velocity_potential_of_air
+    cfname: atmosphere_horizontal_velocity_potential
     description: Scalar potential of the horizontal wind
     type: real
     units: m2 s-1
@@ -1035,6 +1045,7 @@ section:
     type: ddt
     units: none
   - name: potential_temperature_of_air
+    cfname: air_potential_temperature
     description: air potential temperature
     type: real
     units: K
@@ -1120,6 +1131,7 @@ section:
     type: integer
     units: s
   - name: upward_absolute_vorticity_of_air
+    cfname: atmosphere_upward_absolute_vorticity
     description: The upward (kth) component of the curl of the vector wind field
     type: real
     units: s-1
@@ -1513,6 +1525,7 @@ section:
       type: real
       units: mol mol-1
     - name: water_vapor_mixing_ratio_wrt_dry_air
+      cfname: humidity_mixing_ratio
       description: Ratio of the mass of water vapor to the mass of dry air
       type: real
       units: kg kg-1
@@ -1522,6 +1535,7 @@ section:
       type: real
       units: kg kg-1
     - name: water_vapor_mixing_ratio_wrt_moist_air
+      cfname: specific_humidity
       description: Ratio of the mass of water vapor to the mass of moist air
       type: real
       units: kg kg-1
@@ -4543,6 +4557,7 @@ section:
     type: real
     units: fraction
   - name: area_type
+    cfname: area_type
     description: Area type
     type: real
     units: 1

--- a/Metadata-standard-names.yaml
+++ b/Metadata-standard-names.yaml
@@ -491,6 +491,7 @@ section:
       type: real
       units: K
     - name: virtual_temperature
+      cfname: virtual_temperature
       description: The theoretical temperature of dry air that would have the same
         density as moist air
       type: real
@@ -500,6 +501,7 @@ section:
     - name: wind
       description: Movement of air with a net displacement
     - name: wind_speed
+      cfname: wind_speed
       description: Speed of moving air
       type: real
       units: m s-1
@@ -1204,6 +1206,7 @@ section:
     type: real
     units: m s-1
   - name: x_wind
+    cfname: x_wind
     description: Horizontal wind in a direction perpendicular to y_wind
     type: real
     units: m s-1
@@ -1220,6 +1223,7 @@ section:
     type: real
     units: m s-1
   - name: y_wind
+    cfname: y_wind
     description: Horizontal wind in a direction perpendicular to x_wind
     type: real
     units: m s-1
@@ -5058,6 +5062,7 @@ section:
     type: real
     units: frac
   - name: vegetation_area_fraction
+    cfname: vegetation_area_fraction
     description: Vegetation area fraction
     type: real
     units: fraction
@@ -5072,6 +5077,7 @@ section:
     type: real
     units: fraction
   - name: volume_fraction_of_condensed_water_in_soil
+    cfname: volume_fraction_of_condensed_water_in_soil
     description: Volume fraction of condensed water in soil
     type: real
     units: fraction
@@ -5326,6 +5332,7 @@ section:
     type: real
     units: kg-1 s-1
   - name: tendency_of_air_temperature
+    cfname: tendency_of_air_temperature
     description: Change in temperature per unit time
     type: real
     units: K s-1
@@ -5345,6 +5352,7 @@ section:
     type: real
     units: K s-1
   - name: tendency_of_air_temperature_due_to_model_physics
+    cfname: tendency_of_air_temperature_due_to_model_physics
     description: Change in air temperature due to model physics per unit time
     type: real
     units: K s-1
@@ -5367,10 +5375,12 @@ section:
     type: real
     units: J kg-1 s-1
   - name: tendency_of_eastward_wind
+    cfname: tendency_of_eastward_wind
     description: Change in eastward wind per unit time
     type: real
     units: m s-2
   - name: tendency_of_eastward_wind_due_to_model_physics
+    cfname: tendency_of_eastward_wind_due_to_parameterized_physics
     description: Change in eastward wind due to model physics per unit time
     type: real
     units: m s-2
@@ -5384,10 +5394,12 @@ section:
     type: real
     units: kg-1 s-1
   - name: tendency_of_northward_wind
+    cfname: tendency_of_northward_wind
     description: Change in northward wind per unit time
     type: real
     units: m s-2
   - name: tendency_of_northward_wind_due_to_model_physics
+    cfname: tendency_of_northward_wind_due_to_parameterized_physics
     description: Change in northward wind due to model physics per unit time
     type: real
     units: m s-2

--- a/Metadata-standard-names.yaml
+++ b/Metadata-standard-names.yaml
@@ -409,6 +409,7 @@ section:
       type: integer
       units: 1
     - name: reference_pressure
+      cfname: reference_pressure
       description: Some pressure value for comparison to or calculation of other values
       type: real
       units: Pa
@@ -440,16 +441,23 @@ section:
     - name: soil_moisture
       description: Water contained within a soil layer
     - name: soil_temperature
+      cfname: soil_temperature
       description: Temperature of a soil layer
       type: real
       units: K
     - name: solar_declination_angle
       description: The angle between the equator and Earth's orbital plane with the
         Sun
+      type: real
+      units: degrees
     - name: solar_zenith_angle
+      cfname: solar_zenith_angle
       description: The angle between the direction to the sun and the local zenith
         (vertical direction)
+      type: real
+      units: degrees
     - name: surface_skin_temperature
+      cfname: surface_skin_temperature
       description: The temperature of the topmost layer of the surface
       type: real
       units: K
@@ -1017,11 +1025,13 @@ section:
     type: real
     units: m2 s-2
   - name: nonconvective_cloud_area_fraction_in_atmosphere_layer
+    cfname: stratiform_cloud_area_fraction_in_atmosphere_layer
     description: cloud area fraction in atmosphere layer excluding clouds produced
       by the convective schemes
     type: real
     units: fraction
   - name: northward_wind
+    cfname: northward_wind
     description: Wind vector component, positive when directed northward
     type: real
     units: m s-1
@@ -1088,6 +1098,7 @@ section:
     type: real
     units: 1
   - name: relative_humidity
+    cfname: relative_humidity
     description: Relative humidity
     type: real
     units: fraction
@@ -1131,6 +1142,7 @@ section:
     type: real
     units: s-1
   - name: upward_heat_flux_in_air_at_surface
+    cfname: surface_upward_heat_flux_in_air
     description: Upward heat flux in air at surface
     type: real
     units: W m-2
@@ -1257,6 +1269,7 @@ section:
     type: real
     units: m
   - name: ocean_mixed_layer_thickness
+    cfname: ocean_mixed_layer_thickness
     description: Ocean mixed layer thickness
     type: real
     units: m
@@ -1266,22 +1279,27 @@ section:
     type: real
     units: K
   - name: sea_surface_temperature
+    cfname: sea_surface_temperature
     description: Sea surface temperature
     type: real
     units: K
   - name: sea_water_absolute_salinity
+    cfname: sea_water_absolute_salinity
     description: The absolute salinity of sea water
     type: real
     units: g kg-1
   - name: sea_water_depth
+    cfname: sea_floor_depth_below_geoid
     description: The depth of the ocean floor below the surface of the sea
     type: real
     units: m
   - name: sea_water_potential_temperature
+    cfname: sea_water_potential_temperature
     description: sea water potential temperature
     type: real
     units: K
   - name: sea_water_practical_salinity
+    cfname: sea_water_practical_salinity
     description: The practical salinity of sea water
     type: real
     units: PSU
@@ -1290,6 +1308,7 @@ section:
     type: real
     units: ppt m
   - name: sea_water_temperature
+    cfname: sea_water_temperature
     description: The temperature of sea water
     type: real
     units: K
@@ -4629,7 +4648,8 @@ section:
     type: real
     units: K
   - name: density_of_snow_at_surface
-    description: Density of snow at surface
+    cfname: surface_snow_density
+    description: Density of snow accumulated on ground surface
     type: real
     units: kg m-3
   - name: depth_from_snow_surface_at_bottom_interface
@@ -4749,6 +4769,7 @@ section:
     type: real
     units: fraction
   - name: land_ice_area_fraction_of_cell_area
+    cfname: land_ice_area_fraction
     description: fraction of horizontal area of grid cell that is ice over land
     type: real
     units: frac
@@ -4849,6 +4870,7 @@ section:
     type: real
     units: fraction
   - name: roughness_length
+    cfname: surface_roughness_length
     description: surface roughness length
     type: real
     units: cm
@@ -4877,17 +4899,15 @@ section:
     type: real
     units: fraction
   - name: sea_ice_temperature
+    cfname: sea_ice_temperature
     description: Sea ice temperature
     type: real
     units: K
   - name: sea_ice_thickness
+    cfname: sea_ice_thickness
     description: Sea ice thickness
     type: real
     units: m
-  - name: skin_temperature_at_surface
-    description: Skin temperature at surface
-    type: real
-    units: K
   - name: skin_temperature_at_surface_over_ice
     description: Skin temperature at surface over (or where) ice
     type: real
@@ -4905,6 +4925,7 @@ section:
     type: real
     units: K
   - name: slow_soil_pool_mass_content_of_carbon
+    cfname: slow_soil_pool_mass_content_of_carbon
     description: Slow soil pool mass content of carbon
     type: real
     units: g m-2
@@ -4924,10 +4945,6 @@ section:
     description: Snowfall rate on previous timestep
     type: real
     units: mm s-1
-  - name: soil_temperature
-    description: Soil temperature
-    type: real
-    units: K
   - name: soil_temperature_for_lsm
     description: Soil temperature for land surface model
     type: real
@@ -4971,6 +4988,7 @@ section:
     type: real
     units: m s-1
   - name: surface_longwave_emissivity
+    cfname: surface_longwave_emissivity
     description: Surface longwave emissivity
     type: real
     units: fraction
@@ -5031,6 +5049,7 @@ section:
     type: real
     units: fraction
   - name: upward_latent_heat_flux_at_surface
+    cfname: surface_upward_latent_heat_flux
     description: Upward latent heat flux at surface
     type: real
     units: W m-2

--- a/Metadata-standard-names.yaml
+++ b/Metadata-standard-names.yaml
@@ -305,6 +305,7 @@ section:
       type: real
       units: 1
     - name: dimensionless_exner_function
+      cfname: dimensionless_exner_function
       description: Dimensionless formulation of the Exner function with respect to
         1000 hPa
       type: real
@@ -358,10 +359,12 @@ section:
       type: real
       units: m s-1
     - name: geopotential
+      cfname: geopotential
       description: Gravitational potential energy of a unit mass relative to sea level
       type: real
       units: m2 s-2
     - name: geopotential_height
+      cfname: geopotential_height
       description: Geopotential divided by the gravitational constant
       type: real
       units: m
@@ -388,10 +391,6 @@ section:
       description: Flux of longwave radiation across a unit surface
       type: real
       units: W m-2
-    - name: momentum_flux
-      description: Flux of momentum across a unit surface
-      type: real
-      units: Pa
     - name: nonhygroscopic_ice_nucleating_aerosols
       description: Ice-nucleating aerosols with the property of not accumulating liquid
         water
@@ -649,6 +648,7 @@ section:
     type: real
     units: 1
   - name: height_above_mean_sea_level
+    cfname: height_above_mean_sea_level
     description: Height above mean sea level
     type: real
     units: m
@@ -657,10 +657,12 @@ section:
     type: real
     units: m
   - name: latitude
+    cfname: latitude
     description: Latitude
     type: real
     units: degree_north
   - name: longitude
+    cfname: longitude
     description: Longitude
     type: real
     units: degree_east
@@ -708,10 +710,6 @@ section:
     description: Forecast julian day
     type: real
     units: days
-  - name: forecast_time
-    description: Forecast time
-    type: real
-    units: h
   - name: forecast_time_in_seconds
     description: Forecast time in seconds
     type: real
@@ -897,10 +895,12 @@ section:
     type: real
     units: 1
   - name: dry_static_energy
+    cfname: dry_static_energy_content_of_atmosphere_layer
     description: Dry static energy content of atmosphere layer
     type: real
     units: J kg-1
   - name: eastward_wind
+    cfname: eastward_wind
     description: Wind vector component, positive when directed eastward
     type: real
     units: m s-1
@@ -914,10 +914,6 @@ section:
       eastward
     type: real
     units: m s-1
-  - name: geopotential
-    description: Geopotential
-    type: real
-    units: m2 s-2
   - name: geopotential_at_interfaces
     description: Geopotential at interfaces
     type: real
@@ -926,10 +922,6 @@ section:
     description: Geopotential at surface
     type: real
     units: m2 s-2
-  - name: geopotential_height
-    description: geopotential height with respect to sea level
-    type: real
-    units: m
   - name: geopotential_height_at_interfaces
     description: Geopotential height at interfaces
     type: real
@@ -951,6 +943,7 @@ section:
     type: real
     units: m s-2
   - name: horizontal_divergence_of_air
+    cfname: divergence_of_wind
     description: The horizontal divergence of the 2-D vector wind field
     type: real
     units: s-1
@@ -1255,6 +1248,14 @@ section:
     description: Heat content in diurnal thermocline
     type: real
     units: K m
+  - name: molecular_sublayer_temperature_correction_in_sea_water
+    description: Molecular sublayer temperature correction in sea water
+    type: real
+    units: K
+  - name: molecular_sublayer_thickness_in_sea_water
+    description: Molecular sublayer thickness in sea water
+    type: real
+    units: m
   - name: ocean_mixed_layer_thickness
     description: Ocean mixed layer thickness
     type: real
@@ -1300,14 +1301,6 @@ section:
     description: Y current in diurnal thermocline
     type: real
     units: m2 s-1
-  - name: molecular_sublayer_temperature_correction_in_sea_water
-    description: Molecular sublayer temperature correction in sea water
-    type: real
-    units: K
-  - name: molecular_sublayer_thickness_in_sea_water
-    description: Molecular sublayer thickness in sea water
-    type: real
-    units: m
 - name: Tracers
   comment: Tracers are numerically zero-mass particles advected in fluid flow, typically
     representing some trace gas, particle, or other physical substance
@@ -1358,14 +1351,17 @@ section:
       type: real
       units: K-1
     - name: mole_fraction_of_co2_in_air
+      cfname: mole_fraction_of_carbon_dioxide_in_air
       description: Mole fraction of co2 in air
       type: real
       units: mol mol-1
     - name: mole_fraction_of_ozone_in_air
+      cfname: mole_fraction_of_ozone_in_air
       description: Mole fraction of ozone in air
       type: real
       units: mol mol-1
     - name: mole_fraction_of_water_vapor
+      cfname: mole_fraction_of_water_vapor_in_air
       description: Mole fraction of water vapor
       type: real
       units: mol mol-1
@@ -1678,22 +1674,27 @@ section:
       type: real
       units: mm s-1
     - name: effective_radius_of_stratiform_cloud_graupel_particle
+      cfname: effective_radius_of_stratiform_cloud_graupel_particles
       description: Effective radius of stratiform cloud graupel particle
       type: real
       units: um
     - name: effective_radius_of_stratiform_cloud_ice_particle
+      cfname: effective_radius_of_stratiform_cloud_ice_particles
       description: Effective radius of stratiform cloud ice particle
       type: real
       units: um
     - name: effective_radius_of_stratiform_cloud_liquid_water_particle
+      cfname: effective_radius_of_stratiform_cloud_liquid_water_particles
       description: Effective radius of stratiform cloud liquid water particle
       type: real
       units: um
     - name: effective_radius_of_stratiform_cloud_rain_particle
+      cfname: effective_radius_of_stratiform_cloud_rain_particles
       description: Effective radius of stratiform cloud rain particle
       type: real
       units: um
     - name: effective_radius_of_stratiform_cloud_snow_particle
+      cfname: effective_radius_of_stratiform_cloud_snow_particles
       description: Effective radius of stratiform cloud snow particle
       type: real
       units: um
@@ -1875,19 +1876,19 @@ section:
       type: real
       units: kg kg-1
     - name: mass_fraction_of_dust002_in_air
-      description: GOCART DUst bin2 mass fraction
+      description: GOCART Dust bin2 mass fraction
       type: real
       units: kg kg-1
     - name: mass_fraction_of_dust003_in_air
-      description: GOCART DUst bin3 mass fraction
+      description: GOCART Dust bin3 mass fraction
       type: real
       units: kg kg-1
     - name: mass_fraction_of_dust004_in_air
-      description: GOCART DUst bin4 mass fraction
+      description: GOCART Dust bin4 mass fraction
       type: real
       units: kg kg-1
     - name: mass_fraction_of_dust005_in_air
-      description: GOCART DUst bin5 mass fraction
+      description: GOCART Dust bin5 mass fraction
       type: real
       units: kg kg-1
     - name: mass_fraction_of_dust_accumulation_aerosol_particles_in_air
@@ -3895,6 +3896,10 @@ section:
     description: Maximum grid scale
     type: real
     units: m2 rad-2
+  - name: max_soil_moisture_content_for_lsm
+    description: Maximum soil moisture content for land surface model
+    type: real
+    units: m
   - name: max_tendency_of_potential_temperature_of_air_due_to_large_scale_precipitation
     description: Maximum tendency of air potential temperature due to large-scale
       precipitation
@@ -4403,10 +4408,6 @@ section:
       timestep
     type: real
     units: Pa s
-  - name: lwe_surface_snow_from_coupled_process
-    description: Liquid water equivalent surface snow from coupled process
-    type: real
-    units: m
   - name: monin_obukhov_similarity_function_for_heat
     description: Monin obukhov similarity function for heat
     type: real
@@ -4710,6 +4711,7 @@ section:
     type: real
     units: mm s-1
   - name: fast_soil_pool_mass_content_of_carbon
+    cfname: fast_soil_pool_mass_content_of_carbon
     description: Fast soil pool mass content of carbon
     type: real
     units: g m-2
@@ -4742,6 +4744,7 @@ section:
     type: real
     units: m
   - name: land_area_fraction
+    cfname: land_area_fraction
     description: Land area fraction
     type: real
     units: fraction
@@ -4754,6 +4757,7 @@ section:
     type: character
     units: none
   - name: leaf_area_index
+    cfname: leaf_area_index
     description: Leaf area index
     type: real
     units: 1
@@ -4762,6 +4766,7 @@ section:
     type: real
     units: g m-2
   - name: lwe_snowfall_rate
+    cfname: lwe_snowfall_rate
     description: Liquid water equivalent snowfall rate
     type: real
     units: mm s-1
@@ -4769,6 +4774,10 @@ section:
     description: Liquid water equivalent surface snow
     type: real
     units: mm
+  - name: lwe_surface_snow_from_coupled_process
+    description: Liquid water equivalent surface snow from coupled process
+    type: real
+    units: m
   - name: lwe_thickness_of_convective_precipitation_on_previous_timestep
     description: Liquid water equivalent thickness of convective precipitation amount
       on previous timestep
@@ -4812,6 +4821,7 @@ section:
     type: real
     units: mm
   - name: lwe_thickness_of_surface_snow
+    cfname: lwe_thickness_of_surface_snow_amount
     description: Liquid water equivalent thickness of surface snow amount
     type: real
     units: mm
@@ -4819,10 +4829,6 @@ section:
     description: mass per unit area of water in top layer of soil
     type: real
     units: kg m-2
-  - name: max_soil_moisture_content_for_lsm
-    description: Maximum soil moisture content for land surface model
-    type: real
-    units: m
   - name: nir_albedo_strong_cosz
     description: albedo for near-infrared radiation with strong dependence on cosine
       of the zenith angle
@@ -5215,6 +5221,7 @@ section:
   comment: null
   standard_names:
   - name: lagrangian_tendency_of_air_pressure
+    cfname: lagrangian_tendency_of_air_pressure
     description: Vertical pressure velocity
     type: real
     units: Pa s-1

--- a/Metadata-standard-names.yaml
+++ b/Metadata-standard-names.yaml
@@ -274,6 +274,7 @@ section:
       type: real
       units: m2 s-1
     - name: cloud_area_fraction
+      cfname: cloud_area_fraction
       description: Fraction of an area (usually within a grid cell) containing cloud
       type: real
       units: fraction
@@ -631,7 +632,8 @@ section:
   comment: Parameters defining or relating to the coordinate system of the model
   standard_names:
   - name: cell_area
-    description: Cell area
+    cfname: cell_area
+    description: horizontal area of a grid cell
     type: real
     units: m2
   - name: cell_scaling_factor
@@ -1298,6 +1300,14 @@ section:
     description: Y current in diurnal thermocline
     type: real
     units: m2 s-1
+  - name: molecular_sublayer_temperature_correction_in_sea_water
+    description: Molecular sublayer temperature correction in sea water
+    type: real
+    units: K
+  - name: molecular_sublayer_thickness_in_sea_water
+    description: Molecular sublayer thickness in sea water
+    type: real
+    units: m
 - name: Tracers
   comment: Tracers are numerically zero-mass particles advected in fluid flow, typically
     representing some trace gas, particle, or other physical substance
@@ -1582,6 +1592,7 @@ section:
       type: real
       units: kg kg-1
     - name: cloud_ice_mixing_ratio_wrt_dry_air
+      cfname: cloud_ice_mixing_ratio
       description: Ratio of the mass of cloud ice to the mass of dry air
       type: real
       units: kg kg-1
@@ -1610,6 +1621,7 @@ section:
       type: real
       units: kg kg-1
     - name: cloud_liquid_water_mixing_ratio_wrt_dry_air
+      cfname: cloud_liquid_water_mixing_ratio
       description: Ratio of the mass of cloud liquid water to the mass of dry air
       type: real
       units: kg kg-1
@@ -1648,6 +1660,7 @@ section:
       type: real
       units: kg kg-1
     - name: convective_cloud_area_fraction
+      cfname: convective_cloud_area_fraction
       description: Convective cloud area fraction
       type: real
       units: fraction
@@ -4582,11 +4595,13 @@ section:
     type: real
     units: mm
   - name: canopy_temperature
+    cfname: canopy_temperature
     description: Canopy temperature
     type: real
     units: K
   - name: canopy_water_mass_content
-    description: Canopy water mass content
+    cfname: canopy_water_amount
+    description: Water mass per unit area in the canopy
     type: real
     units: kg m-2
   - name: cumulative_lwe_thickness_of_convective_precipitation_between_sw_radiation_calls
@@ -4806,14 +4821,6 @@ section:
     units: kg m-2
   - name: max_soil_moisture_content_for_lsm
     description: Maximum soil moisture content for land surface model
-    type: real
-    units: m
-  - name: molecular_sublayer_temperature_correction_in_sea_water
-    description: Molecular sublayer temperature correction in sea water
-    type: real
-    units: K
-  - name: molecular_sublayer_thickness_in_sea_water
-    description: Molecular sublayer thickness in sea water
     type: real
     units: m
   - name: nir_albedo_strong_cosz

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -366,6 +366,7 @@
         <type units="K">real</type>
       </standard_name>
       <standard_name name="virtual_temperature" description="The theoretical temperature of dry air that would have the same density as moist air">
+        <cfname>virtual_temperature</cfname>
         <type units="K">real</type>
       </standard_name>
       <standard_name name="water_vapor" description="Water in the gaseous phase">
@@ -373,6 +374,7 @@
       <standard_name name="wind" description="Movement of air with a net displacement">
       </standard_name>
       <standard_name name="wind_speed" description="Speed of moving air">
+        <cfname>wind_speed</cfname>
         <type units="m s-1">real</type>
       </standard_name>
       <standard_name name="wind_stress" description="Shear stress exerted by wind parallel to the surface">
@@ -887,6 +889,7 @@
       <type units="m s-1">real</type>
     </standard_name>
     <standard_name name="x_wind" description="Horizontal wind in a direction perpendicular to y_wind">
+      <cfname>x_wind</cfname>
       <type units="m s-1">real</type>
     </standard_name>
     <standard_name name="x_wind_at_surface_adjacent_layer">
@@ -899,6 +902,7 @@
       <type units="m s-1">real</type>
     </standard_name>
     <standard_name name="y_wind" description="Horizontal wind in a direction perpendicular to x_wind">
+      <cfname>y_wind</cfname>
       <type units="m s-1">real</type>
     </standard_name>
     <standard_name name="y_wind_at_surface_adjacent_layer">
@@ -3595,6 +3599,7 @@
       <type units="frac">real</type>
     </standard_name>
     <standard_name name="vegetation_area_fraction">
+      <cfname>vegetation_area_fraction</cfname>
       <type units="fraction">real</type>
     </standard_name>
     <standard_name name="vis_albedo_strong_cosz" description="albedo for visible radiation with strong dependence on cosine of the zenith angle">
@@ -3604,6 +3609,7 @@
       <type units="fraction">real</type>
     </standard_name>
     <standard_name name="volume_fraction_of_condensed_water_in_soil">
+      <cfname>volume_fraction_of_condensed_water_in_soil</cfname>
       <type units="fraction">real</type>
     </standard_name>
     <standard_name name="volume_fraction_of_frozen_soil_moisture_for_lsm" description="Volume fraction of frozen soil moisture for land surface model">
@@ -3779,6 +3785,7 @@
       <type units="kg-1 s-1">real</type>
     </standard_name>
     <standard_name name="tendency_of_air_temperature" description="Change in temperature per unit time">
+      <cfname>tendency_of_air_temperature</cfname>
       <type units="K s-1">real</type>
     </standard_name>
     <standard_name name="tendency_of_air_temperature_due_to_integrated_dynamics_through_earths_atmosphere">
@@ -3791,6 +3798,7 @@
       <type units="K s-1">real</type>
     </standard_name>
     <standard_name name="tendency_of_air_temperature_due_to_model_physics" description="Change in air temperature due to model physics per unit time">
+      <cfname>tendency_of_air_temperature_due_to_model_physics</cfname>
       <type units="K s-1">real</type>
     </standard_name>
     <standard_name name="tendency_of_air_temperature_due_to_nonphysics">
@@ -3806,9 +3814,11 @@
       <type units="J kg-1 s-1">real</type>
     </standard_name>
     <standard_name name="tendency_of_eastward_wind" description="Change in eastward wind per unit time">
+      <cfname>tendency_of_eastward_wind</cfname>
       <type units="m s-2">real</type>
     </standard_name>
     <standard_name name="tendency_of_eastward_wind_due_to_model_physics" description="Change in eastward wind due to model physics per unit time">
+      <cfname>tendency_of_eastward_wind_due_to_parameterized_physics</cfname>
       <type units="m s-2">real</type>
     </standard_name>
     <standard_name name="tendency_of_hygroscopic_aerosols_at_surface_adjacent_layer">
@@ -3818,9 +3828,11 @@
       <type units="kg-1 s-1">real</type>
     </standard_name>
     <standard_name name="tendency_of_northward_wind" description="Change in northward wind per unit time">
+      <cfname>tendency_of_northward_wind</cfname>
       <type units="m s-2">real</type>
     </standard_name>
     <standard_name name="tendency_of_northward_wind_due_to_model_physics" description="Change in northward wind due to model physics per unit time">
+      <cfname>tendency_of_northward_wind_due_to_parameterized_physics</cfname>
       <type units="m s-2">real</type>
     </standard_name>
     <standard_name name="tendency_of_potential_temperature_of_air" description="Change in potential temperature per unit time">

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -305,6 +305,7 @@
         <type units="1">integer</type>
       </standard_name>
       <standard_name name="reference_pressure" description="Some pressure value for comparison to or calculation of other values">
+        <cfname>reference_pressure</cfname>
         <type units="Pa">real</type>
       </standard_name>
       <standard_name name="relative_humidity" description="Ratio of the vapor pressure to the saturation vapor pressure (for liquid water unless otherwise specified)">
@@ -327,13 +328,18 @@
       <standard_name name="soil_moisture" description="Water contained within a soil layer">
       </standard_name>
       <standard_name name="soil_temperature" description="Temperature of a soil layer">
+        <cfname>soil_temperature</cfname>
         <type units="K">real</type>
       </standard_name>
       <standard_name name="solar_declination_angle" description="The angle between the equator and Earth's orbital plane with the Sun">
+        <type units="degrees">real</type>
       </standard_name>
       <standard_name name="solar_zenith_angle" description="The angle between the direction to the sun and the local zenith (vertical direction)">
+        <cfname>solar_zenith_angle</cfname>
+        <type units="degrees">real</type>
       </standard_name>
       <standard_name name="surface_skin_temperature" description="The temperature of the topmost layer of the surface">
+        <cfname>surface_skin_temperature</cfname>
         <type units="K">real</type>
       </standard_name>
       <standard_name name="temperature">
@@ -755,9 +761,11 @@
       <type units="m2 s-2">real</type>
     </standard_name>
     <standard_name name="nonconvective_cloud_area_fraction_in_atmosphere_layer" description="cloud area fraction in atmosphere layer excluding clouds produced by the convective schemes">
+      <cfname>stratiform_cloud_area_fraction_in_atmosphere_layer</cfname>
       <type units="fraction">real</type>
     </standard_name>
     <standard_name name="northward_wind" description="Wind vector component, positive when directed northward">
+      <cfname>northward_wind</cfname>
       <type units="m s-1">real</type>
     </standard_name>
     <standard_name name="northward_wind_at_10m" description="Wind vector component at 10 meters above surface, positive when directed northward">
@@ -804,6 +812,7 @@
       <type units="1">real</type>
     </standard_name>
     <standard_name name="relative_humidity">
+      <cfname>relative_humidity</cfname>
       <type units="fraction">real</type>
     </standard_name>
     <standard_name name="relative_humidity_at_2m">
@@ -835,6 +844,7 @@
       <type units="s-1">real</type>
     </standard_name>
     <standard_name name="upward_heat_flux_in_air_at_surface">
+      <cfname>surface_upward_heat_flux_in_air</cfname>
       <type units="W m-2">real</type>
     </standard_name>
     <standard_name name="us_standard_air_pressure_at_sea_level" description="US Standard Atmospheric pressure at sea level">
@@ -924,30 +934,37 @@
       <type units="m">real</type>
     </standard_name>
     <standard_name name="ocean_mixed_layer_thickness">
+      <cfname>ocean_mixed_layer_thickness</cfname>
       <type units="m">real</type>
     </standard_name>
     <standard_name name="reference_sea_surface_temperature" description="Foundation/reference temperature for calculating diurnal ocean temperature changes">
       <type units="K">real</type>
     </standard_name>
     <standard_name name="sea_surface_temperature">
+      <cfname>sea_surface_temperature</cfname>
       <type units="K">real</type>
     </standard_name>
     <standard_name name="sea_water_absolute_salinity" description="The absolute salinity of sea water">
+      <cfname>sea_water_absolute_salinity</cfname>
       <type units="g kg-1">real</type>
     </standard_name>
     <standard_name name="sea_water_depth" description="The depth of the ocean floor below the surface of the sea">
+      <cfname>sea_floor_depth_below_geoid</cfname>
       <type units="m">real</type>
     </standard_name>
     <standard_name name="sea_water_potential_temperature" description="sea water potential temperature">
+      <cfname>sea_water_potential_temperature</cfname>
       <type units="K">real</type>
     </standard_name>
     <standard_name name="sea_water_practical_salinity" description="The practical salinity of sea water">
+      <cfname>sea_water_practical_salinity</cfname>
       <type units="PSU">real</type>
     </standard_name>
     <standard_name name="sea_water_salinity_in_diurnal_thermocline">
       <type units="ppt m">real</type>
     </standard_name>
     <standard_name name="sea_water_temperature" description="The temperature of sea water">
+      <cfname>sea_water_temperature</cfname>
       <type units="K">real</type>
     </standard_name>
     <standard_name name="x_current_in_diurnal_thermocline">
@@ -3276,7 +3293,8 @@
     <standard_name name="deep_soil_temperature">
       <type units="K">real</type>
     </standard_name>
-    <standard_name name="density_of_snow_at_surface">
+    <standard_name name="density_of_snow_at_surface" description="Density of snow accumulated on ground surface">
+      <cfname>surface_snow_density</cfname>
       <type units="kg m-3">real</type>
     </standard_name>
     <standard_name name="depth_from_snow_surface_at_bottom_interface" description="depth from the top of the snow surface at the bottom of the soil layer">
@@ -3366,6 +3384,7 @@
       <type units="fraction">real</type>
     </standard_name>
     <standard_name name="land_ice_area_fraction_of_cell_area" description="fraction of horizontal area of grid cell that is ice over land">
+      <cfname>land_ice_area_fraction</cfname>
       <type units="frac">real</type>
     </standard_name>
     <standard_name name="land_surface_perturbation_variables">
@@ -3435,6 +3454,7 @@
       <type units="fraction">real</type>
     </standard_name>
     <standard_name name="roughness_length" description="surface roughness length">
+      <cfname>surface_roughness_length</cfname>
       <type units="cm">real</type>
     </standard_name>
     <standard_name name="roughness_length_from_wave_model" description="surface roughness length from wave model">
@@ -3456,13 +3476,12 @@
       <type units="fraction">real</type>
     </standard_name>
     <standard_name name="sea_ice_temperature">
+      <cfname>sea_ice_temperature</cfname>
       <type units="K">real</type>
     </standard_name>
     <standard_name name="sea_ice_thickness">
+      <cfname>sea_ice_thickness</cfname>
       <type units="m">real</type>
-    </standard_name>
-    <standard_name name="skin_temperature_at_surface" description="Skin temperature at surface">
-      <type units="K">real</type>
     </standard_name>
     <standard_name name="skin_temperature_at_surface_over_ice" description="Skin temperature at surface over (or where) ice">
       <type units="K">real</type>
@@ -3477,6 +3496,7 @@
       <type units="K">real</type>
     </standard_name>
     <standard_name name="slow_soil_pool_mass_content_of_carbon">
+      <cfname>slow_soil_pool_mass_content_of_carbon</cfname>
       <type units="g m-2">real</type>
     </standard_name>
     <standard_name name="snow_area_fraction_at_surface_over_ice">
@@ -3490,9 +3510,6 @@
     </standard_name>
     <standard_name name="snowfall_rate_on_previous_timestep">
       <type units="mm s-1">real</type>
-    </standard_name>
-    <standard_name name="soil_temperature">
-      <type units="K">real</type>
     </standard_name>
     <standard_name name="soil_temperature_for_lsm" description="Soil temperature for land surface model">
       <type units="K">real</type>
@@ -3525,6 +3542,7 @@
       <type units="m s-1">real</type>
     </standard_name>
     <standard_name name="surface_longwave_emissivity">
+      <cfname>surface_longwave_emissivity</cfname>
       <type units="fraction">real</type>
     </standard_name>
     <standard_name name="surface_longwave_emissivity_over_ice">
@@ -3570,6 +3588,7 @@
       <type units="fraction">real</type>
     </standard_name>
     <standard_name name="upward_latent_heat_flux_at_surface">
+      <cfname>surface_upward_latent_heat_flux</cfname>
       <type units="W m-2">real</type>
     </standard_name>
     <standard_name name="urban_area_fraction_of_cell_area" description="fraction of horizontal area of grid cell that is urban">

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -203,6 +203,7 @@
         <type units="m2 s-1">real</type>
       </standard_name>
       <standard_name name="cloud_area_fraction" description="Fraction of an area (usually within a grid cell) containing cloud">
+        <cfname>cloud_area_fraction</cfname>
         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="cloud_condensate" description="Amount of condensed water in cloud">
@@ -468,7 +469,8 @@
     </standard_name>
   </section>
   <section name="Coordinates" comment="Parameters defining or relating to the coordinate system of the model">
-    <standard_name name="cell_area">
+    <standard_name name="cell_area" description="horizontal area of a grid cell">
+      <cfname>cell_area</cfname>
       <type units="m2">real</type>
     </standard_name>
     <standard_name name="cell_scaling_factor">
@@ -951,6 +953,12 @@
     <standard_name name="y_current_in_diurnal_thermocline">
       <type units="m2 s-1">real</type>
     </standard_name>
+    <standard_name name="molecular_sublayer_temperature_correction_in_sea_water">
+      <type units="K">real</type>
+    </standard_name>
+    <standard_name name="molecular_sublayer_thickness_in_sea_water">
+      <type units="m">real</type>
+    </standard_name>
   </section>
   <section name="Tracers" comment="Tracers are numerically zero-mass particles advected in fluid flow, typically representing some trace gas, particle, or other physical substance">
     <standard_name name="chemical_tracer_scavenging_fractions">
@@ -1147,6 +1155,7 @@
         <type units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="cloud_ice_mixing_ratio_wrt_dry_air" description="Ratio of the mass of cloud ice to the mass of dry air">
+        <cfname>cloud_ice_mixing_ratio</cfname>
         <type units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="cloud_ice_mixing_ratio_wrt_dry_air_at_top_interfaces" description="Ratio of the mass of cloud ice to the mass of dry air at all interfaces excluding surface">
@@ -1165,6 +1174,7 @@
         <type units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="cloud_liquid_water_mixing_ratio_wrt_dry_air" description="Ratio of the mass of cloud liquid water to the mass of dry air">
+        <cfname>cloud_liquid_water_mixing_ratio</cfname>
         <type units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="cloud_liquid_water_mixing_ratio_wrt_dry_air_at_top_interfaces" description="Ratio of the mass of cloud liquid water to the mass of dry air at all interfaces excluding surface">
@@ -1189,6 +1199,7 @@
         <type units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="convective_cloud_area_fraction">
+        <cfname>convective_cloud_area_fraction</cfname>
         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="convective_cloud_condensate_after_rainout">
@@ -3238,9 +3249,11 @@
       <type units="mm">real</type>
     </standard_name>
     <standard_name name="canopy_temperature">
+      <cfname>canopy_temperature</cfname>
       <type units="K">real</type>
     </standard_name>
-    <standard_name name="canopy_water_mass_content">
+    <standard_name name="canopy_water_mass_content" description="Water mass per unit area in the canopy">
+      <cfname>canopy_water_amount</cfname>
       <type units="kg m-2">real</type>
     </standard_name>
     <standard_name name="cumulative_lwe_thickness_of_convective_precipitation_between_sw_radiation_calls" description="Cumulative liquid water equivalent thickness of convective precipitation amount between shortwave radiation calls">
@@ -3397,12 +3410,6 @@
       <type units="kg m-2">real</type>
     </standard_name>
     <standard_name name="max_soil_moisture_content_for_lsm" description="Maximum soil moisture content for land surface model">
-      <type units="m">real</type>
-    </standard_name>
-    <standard_name name="molecular_sublayer_temperature_correction_in_sea_water">
-      <type units="K">real</type>
-    </standard_name>
-    <standard_name name="molecular_sublayer_thickness_in_sea_water">
       <type units="m">real</type>
     </standard_name>
     <standard_name name="nir_albedo_strong_cosz" description="albedo for near-infrared radiation with strong dependence on cosine of the zenith angle">

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -483,15 +483,18 @@
       <type units="1">real</type>
     </standard_name>
     <standard_name name="height_above_mean_sea_level">
+      <cfname>height_above_mean_sea_level</cfname>
       <type units="m">real</type>
     </standard_name>
     <standard_name name="height_above_mean_sea_level_at_surface" description="Height above mean sea level at local surface">
       <type units="m">real</type>
     </standard_name>
     <standard_name name="latitude">
+      <cfname>latitude</cfname>
       <type units="degree_north">real</type>
     </standard_name>
     <standard_name name="longitude">
+      <cfname>longitude</cfname>
       <type units="degree_east">real</type>
     </standard_name>
     <standard_name name="sigma_pressure_hybrid_coordinate_a_coefficient">
@@ -914,6 +917,12 @@
     <standard_name name="heat_content_in_diurnal_thermocline">
       <type units="K m">real</type>
     </standard_name>
+    <standard_name name="molecular_sublayer_temperature_correction_in_sea_water">
+      <type units="K">real</type>
+    </standard_name>
+    <standard_name name="molecular_sublayer_thickness_in_sea_water">
+      <type units="m">real</type>
+    </standard_name>
     <standard_name name="ocean_mixed_layer_thickness">
       <type units="m">real</type>
     </standard_name>
@@ -946,12 +955,6 @@
     </standard_name>
     <standard_name name="y_current_in_diurnal_thermocline">
       <type units="m2 s-1">real</type>
-    </standard_name>
-    <standard_name name="molecular_sublayer_temperature_correction_in_sea_water">
-      <type units="K">real</type>
-    </standard_name>
-    <standard_name name="molecular_sublayer_thickness_in_sea_water">
-      <type units="m">real</type>
     </standard_name>
   </section>
   <section name="Tracers" comment="Tracers are numerically zero-mass particles advected in fluid flow, typically representing some trace gas, particle, or other physical substance">
@@ -986,12 +989,15 @@
         <type units="K-1">real</type>
       </standard_name>
       <standard_name name="mole_fraction_of_co2_in_air">
+        <cfname>mole_fraction_of_carbon_dioxide_in_air</cfname>
         <type units="mol mol-1">real</type>
       </standard_name>
       <standard_name name="mole_fraction_of_ozone_in_air">
+        <cfname>mole_fraction_of_ozone_in_air</cfname>
         <type units="mol mol-1">real</type>
       </standard_name>
       <standard_name name="mole_fraction_of_water_vapor">
+        <cfname>mole_fraction_of_water_vapor_in_air</cfname>
         <type units="mol mol-1">real</type>
       </standard_name>
       <standard_name name="number_density_of_anomalous_oxygen" description="Number density of energetic, non-thermal atomic oxygen as defined in MSIS">
@@ -1350,16 +1356,16 @@
       <standard_name name="mass_fraction_of_dust001_in_air" description="GOCART Dust bin1 mass fraction">
         <type units="kg kg-1">real</type>
       </standard_name>
-      <standard_name name="mass_fraction_of_dust002_in_air" description="GOCART DUst bin2 mass fraction">
+      <standard_name name="mass_fraction_of_dust002_in_air" description="GOCART Dust bin2 mass fraction">
         <type units="kg kg-1">real</type>
       </standard_name>
-      <standard_name name="mass_fraction_of_dust003_in_air" description="GOCART DUst bin3 mass fraction">
+      <standard_name name="mass_fraction_of_dust003_in_air" description="GOCART Dust bin3 mass fraction">
         <type units="kg kg-1">real</type>
       </standard_name>
-      <standard_name name="mass_fraction_of_dust004_in_air" description="GOCART DUst bin4 mass fraction">
+      <standard_name name="mass_fraction_of_dust004_in_air" description="GOCART Dust bin4 mass fraction">
         <type units="kg kg-1">real</type>
       </standard_name>
-      <standard_name name="mass_fraction_of_dust005_in_air" description="GOCART DUst bin5 mass fraction">
+      <standard_name name="mass_fraction_of_dust005_in_air" description="GOCART Dust bin5 mass fraction">
         <type units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="mass_fraction_of_dust_accumulation_aerosol_particles_in_air" description="Mass fraction of accumulation mode dust aerosol particles">
@@ -2770,6 +2776,9 @@
     <standard_name name="max_grid_scale" description="Maximum grid scale">
       <type units="m2 rad-2">real</type>
     </standard_name>
+    <standard_name name="max_soil_moisture_content_for_lsm" description="Maximum soil moisture content for land surface model">
+      <type units="m">real</type>
+    </standard_name>
     <standard_name name="max_tendency_of_potential_temperature_of_air_due_to_large_scale_precipitation" description="Maximum tendency of air potential temperature due to large-scale precipitation">
       <type units="K s-1">real</type>
     </standard_name>
@@ -3109,9 +3118,6 @@
     <standard_name name="cumulative_y_momentum_flux_at_surface_for_coupling_multiplied_by_timestep">
       <type units="Pa s">real</type>
     </standard_name>
-    <standard_name name="lwe_surface_snow_from_coupled_process" description="Liquid water equivalent surface snow from coupled process">
-      <type units="m">real</type>
-    </standard_name>
     <standard_name name="monin_obukhov_similarity_function_for_heat">
       <type units="1">real</type>
     </standard_name>
@@ -3356,6 +3362,7 @@
       <type units="m">real</type>
     </standard_name>
     <standard_name name="land_area_fraction">
+      <cfname>land_area_fraction</cfname>
       <type units="fraction">real</type>
     </standard_name>
     <standard_name name="land_ice_area_fraction_of_cell_area" description="fraction of horizontal area of grid cell that is ice over land">
@@ -3365,16 +3372,21 @@
       <type units="none">character</type>
     </standard_name>
     <standard_name name="leaf_area_index">
+      <cfname>leaf_area_index</cfname>
       <type units="1">real</type>
     </standard_name>
     <standard_name name="leaf_mass_content">
       <type units="g m-2">real</type>
     </standard_name>
     <standard_name name="lwe_snowfall_rate" description="Liquid water equivalent snowfall rate">
+      <cfname>lwe_snowfall_rate</cfname>
       <type units="mm s-1">real</type>
     </standard_name>
     <standard_name name="lwe_surface_snow" description="Liquid water equivalent surface snow">
       <type units="mm">real</type>
+    </standard_name>
+    <standard_name name="lwe_surface_snow_from_coupled_process" description="Liquid water equivalent surface snow from coupled process">
+      <type units="m">real</type>
     </standard_name>
     <standard_name name="lwe_thickness_of_convective_precipitation_on_previous_timestep" description="Liquid water equivalent thickness of convective precipitation amount on previous timestep">
       <type units="m">real</type>
@@ -3404,13 +3416,11 @@
       <type units="mm">real</type>
     </standard_name>
     <standard_name name="lwe_thickness_of_surface_snow" description="Liquid water equivalent thickness of surface snow amount">
+      <cfname>lwe_thickness_of_surface_snow_amount</cfname>
       <type units="mm">real</type>
     </standard_name>
     <standard_name name="mass_content_of_water_in_top_soil_layer" description="mass per unit area of water in top layer of soil">
       <type units="kg m-2">real</type>
-    </standard_name>
-    <standard_name name="max_soil_moisture_content_for_lsm" description="Maximum soil moisture content for land surface model">
-      <type units="m">real</type>
     </standard_name>
     <standard_name name="nir_albedo_strong_cosz" description="albedo for near-infrared radiation with strong dependence on cosine of the zenith angle">
       <type units="fraction">real</type>
@@ -3695,6 +3705,7 @@
   </section>
   <section name="Tendencies">
     <standard_name name="lagrangian_tendency_of_air_pressure" description="Vertical pressure velocity">
+      <cfname>lagrangian_tendency_of_air_pressure</cfname>
       <type units="Pa s-1">real</type>
     </standard_name>
     <standard_name name="process_split_cumulative_tendency_of_air_temperature">

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -6,6 +6,7 @@
         <type units="m2">real</type>
       </standard_name>
       <standard_name name="area_fraction" description="The fraction of an area where some condition applies">
+        <cfname>area_fraction</cfname>
         <type units="1">real</type>
       </standard_name>
       <standard_name name="binary_mask" description="A field consisting of either 0 or 1 at every point">
@@ -191,12 +192,14 @@
         <type units="Pa">real</type>
       </standard_name>
       <standard_name name="air_temperature" description="The temperature of air">
+        <cfname>air_temperature</cfname>
         <type units="K">real</type>
       </standard_name>
       <standard_name name="albedo" description="The fraction of incident radiation reflected by a surface">
         <type units="1">real</type>
       </standard_name>
       <standard_name name="atmosphere_heat_diffusivity">
+        <cfname>atmosphere_heat_diffusivity</cfname>
         <type units="m2 s-1">real</type>
       </standard_name>
       <standard_name name="cloud_area_fraction" description="Fraction of an area (usually within a grid cell) containing cloud">
@@ -496,6 +499,7 @@
       <type units="1">real</type>
     </standard_name>
     <standard_name name="sigma_pressure_hybrid_vertical_coordinate">
+      <cfname>atmosphere_hybrid_sigma_pressure_coordinate</cfname>
       <type units="1">real</type>
     </standard_name>
     <standard_name name="sine_of_latitude">
@@ -548,6 +552,7 @@
   </section>
   <section name="Atmospheric properties">
     <standard_name name="air_pressure" description="Midpoint air pressure">
+      <cfname>air_pressure</cfname>
       <type units="Pa">real</type>
     </standard_name>
     <standard_name name="air_pressure_at_interfaces">
@@ -557,15 +562,18 @@
       <type units="Pa">real</type>
     </standard_name>
     <standard_name name="air_pressure_at_sea_level">
+      <cfname>air_pressure_at_mean_sea_level</cfname>
       <type units="Pa">real</type>
     </standard_name>
     <standard_name name="air_pressure_at_surface" description="Air pressure at local surface">
+      <cfname>surface_air_pressure</cfname>
       <type units="Pa">real</type>
     </standard_name>
     <standard_name name="air_pressure_at_surface_adjacent_layer">
       <type units="Pa">real</type>
     </standard_name>
     <standard_name name="air_pressure_at_top_of_atmosphere_model">
+      <cfname>air_pressure_at_top_of_atmosphere_model</cfname>
       <type units="Pa">real</type>
     </standard_name>
     <standard_name name="air_pressure_extended_up_by_1">
@@ -611,6 +619,7 @@
       <type units="K">real</type>
     </standard_name>
     <standard_name name="atmosphere_boundary_layer_thickness">
+      <cfname>atmosphere_boundary_layer_thickness</cfname>
       <type units="m">real</type>
     </standard_name>
     <standard_name name="atmosphere_heat_diffusivity_due_to_background">
@@ -698,6 +707,7 @@
       <type units="m2 s-1">real</type>
     </standard_name>
     <standard_name name="horizontal_velocity_potential_of_air" description="Scalar potential of the horizontal wind">
+      <cfname>atmosphere_horizontal_velocity_potential</cfname>
       <type units="m2 s-1">real</type>
     </standard_name>
     <standard_name name="is_initialized_physics_grid" description="Flag to indicate if physics grid is initialized">
@@ -761,6 +771,7 @@
       <type units="none">ddt</type>
     </standard_name>
     <standard_name name="potential_temperature_of_air" description="air potential temperature">
+      <cfname>air_potential_temperature</cfname>
       <type units="K">real</type>
     </standard_name>
     <standard_name name="potential_temperature_of_air_at_2m">
@@ -821,6 +832,7 @@
       <type units="s">integer</type>
     </standard_name>
     <standard_name name="upward_absolute_vorticity_of_air" description="The upward (kth) component of the curl of the vector wind field">
+      <cfname>atmosphere_upward_absolute_vorticity</cfname>
       <type units="s-1">real</type>
     </standard_name>
     <standard_name name="upward_heat_flux_in_air_at_surface">
@@ -1098,12 +1110,14 @@
         <type units="mol mol-1">real</type>
       </standard_name>
       <standard_name name="water_vapor_mixing_ratio_wrt_dry_air" description="Ratio of the mass of water vapor to the mass of dry air">
+        <cfname>humidity_mixing_ratio</cfname>
         <type units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="water_vapor_mixing_ratio_wrt_dry_air_at_top_interfaces" description="Ratio of the mass of water vapor to the mass of dry air at all interfaces excluding surface">
         <type units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="water_vapor_mixing_ratio_wrt_moist_air" description="Ratio of the mass of water vapor to the mass of moist air">
+        <cfname>specific_humidity</cfname>
         <type units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water" description="Ratio of the mass of water vapor to the mass of moist air and hydrometeors">
@@ -3205,6 +3219,7 @@
       <type units="fraction">real</type>
     </standard_name>
     <standard_name name="area_type">
+      <cfname>area_type</cfname>
       <type units="1">real</type>
     </standard_name>
     <standard_name name="area_type_from_coupled_process">

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -228,6 +228,7 @@
         <type units="1">real</type>
       </standard_name>
       <standard_name name="dimensionless_exner_function" description="Dimensionless formulation of the Exner function with respect to 1000 hPa" comment="The formulation of the exner function in an NWP context is (p/p0)^(Rd/cp), where p0 is some reference pressure. For the purposes of the standard names, this reference pressure is assumed as 1000 hPa unless specified otherwise; i.e. dimensionless_exner_function_wrt_air_pressure_at_surface would use the pressure at the surface as P0. Note that this is numerically equivalent to T/theta (temperature divided by potential temperature), where again theta is calculated with respect to 1000 hPa if not specified. Note that this definition is distinct from the dimensional exner_function standard name; see that entry for further comments. ">
+        <cfname>dimensionless_exner_function</cfname>
         <type units="1">real</type>
       </standard_name>
       <standard_name name="direct_nir_albedo" description="Albedo of direct incident near-infrared radiation">
@@ -264,9 +265,11 @@
         <type units="m s-1">real</type>
       </standard_name>
       <standard_name name="geopotential" description="Gravitational potential energy of a unit mass relative to sea level">
+        <cfname>geopotential</cfname>
         <type units="m2 s-2">real</type>
       </standard_name>
       <standard_name name="geopotential_height" description="Geopotential divided by the gravitational constant">
+        <cfname>geopotential_height</cfname>
         <type units="m">real</type>
       </standard_name>
       <standard_name name="graupel" description="Precipitation consisting of heavily rimed ice crystals">
@@ -287,9 +290,6 @@
       </standard_name>
       <standard_name name="longwave_flux" description="Flux of longwave radiation across a unit surface">
         <type units="W m-2">real</type>
-      </standard_name>
-      <standard_name name="momentum_flux" description="Flux of momentum across a unit surface">
-        <type units="Pa">real</type>
       </standard_name>
       <standard_name name="nonhygroscopic_ice_nucleating_aerosols" description="Ice-nucleating aerosols with the property of not accumulating liquid water">
       </standard_name>
@@ -524,9 +524,6 @@
     <standard_name name="forecast_julian_day">
       <type units="days">real</type>
     </standard_name>
-    <standard_name name="forecast_time">
-      <type units="h">real</type>
-    </standard_name>
     <standard_name name="forecast_time_in_seconds">
       <type units="s">real</type>
     </standard_name>
@@ -664,9 +661,11 @@
       <type units="1">real</type>
     </standard_name>
     <standard_name name="dry_static_energy" description="Dry static energy content of atmosphere layer">
+      <cfname>dry_static_energy_content_of_atmosphere_layer</cfname>
       <type units="J kg-1">real</type>
     </standard_name>
     <standard_name name="eastward_wind" description="Wind vector component, positive when directed eastward">
+      <cfname>eastward_wind</cfname>
       <type units="m s-1">real</type>
     </standard_name>
     <standard_name name="eastward_wind_at_10m" description="Wind vector component at 10 meters above surface, positive when directed eastward">
@@ -675,17 +674,11 @@
     <standard_name name="eastward_wind_at_surface" description="Wind vector component closest to surface, positive when directed eastward">
       <type units="m s-1">real</type>
     </standard_name>
-    <standard_name name="geopotential">
-      <type units="m2 s-2">real</type>
-    </standard_name>
     <standard_name name="geopotential_at_interfaces">
       <type units="m2 s-2">real</type>
     </standard_name>
     <standard_name name="geopotential_at_surface">
       <type units="m2 s-2">real</type>
-    </standard_name>
-    <standard_name name="geopotential_height" description="geopotential height with respect to sea level">
-      <type units="m">real</type>
     </standard_name>
     <standard_name name="geopotential_height_at_interfaces">
       <type units="m">real</type>
@@ -703,6 +696,7 @@
       <type units="m s-2">real</type>
     </standard_name>
     <standard_name name="horizontal_divergence_of_air" description="The horizontal divergence of the 2-D vector wind field">
+      <cfname>divergence_of_wind</cfname>
       <type units="s-1">real</type>
     </standard_name>
     <standard_name name="horizontal_streamfunction_of_air" description="Scalar function describing the streamlines of the horizontal wind">
@@ -1212,18 +1206,23 @@
         <type units="mm s-1">real</type>
       </standard_name>
       <standard_name name="effective_radius_of_stratiform_cloud_graupel_particle">
+        <cfname>effective_radius_of_stratiform_cloud_graupel_particles</cfname>
         <type units="um">real</type>
       </standard_name>
       <standard_name name="effective_radius_of_stratiform_cloud_ice_particle">
+        <cfname>effective_radius_of_stratiform_cloud_ice_particles</cfname>
         <type units="um">real</type>
       </standard_name>
       <standard_name name="effective_radius_of_stratiform_cloud_liquid_water_particle">
+        <cfname>effective_radius_of_stratiform_cloud_liquid_water_particles</cfname>
         <type units="um">real</type>
       </standard_name>
       <standard_name name="effective_radius_of_stratiform_cloud_rain_particle">
+        <cfname>effective_radius_of_stratiform_cloud_rain_particles</cfname>
         <type units="um">real</type>
       </standard_name>
       <standard_name name="effective_radius_of_stratiform_cloud_snow_particle">
+        <cfname>effective_radius_of_stratiform_cloud_snow_particles</cfname>
         <type units="um">real</type>
       </standard_name>
       <standard_name name="graupel_mixing_ratio_wrt_moist_air" description="Graupel mass mixing ratio with respect to moist air">
@@ -3332,6 +3331,7 @@
       <type units="mm s-1">real</type>
     </standard_name>
     <standard_name name="fast_soil_pool_mass_content_of_carbon">
+      <cfname>fast_soil_pool_mass_content_of_carbon</cfname>
       <type units="g m-2">real</type>
     </standard_name>
     <standard_name name="fine_root_mass_content">

--- a/standard_names.xsd
+++ b/standard_names.xsd
@@ -48,6 +48,10 @@
 
   <xs:complexType name="stdname_type">
     <xs:sequence>
+      <xs:element name="cfname"
+                  type="xs:string"
+                  minOccurs="0"
+                  maxOccurs="1"/>
       <xs:element name="type"
                   type="md_type"
                   minOccurs="0"

--- a/tools/write_standard_name_table.py
+++ b/tools/write_standard_name_table.py
@@ -178,22 +178,17 @@ def parse_section(snl, sec, level='##'):
             parse_section(snl, std_name, level + '#')
             continue
         stdn_name = std_name.get('name')
-        cfname_elem = std_name.find('cfname')
-        if cfname_elem is not None and cfname_elem.text is not None:
-            stdn_cfname = cfname_elem.text.strip()
-        else:
-            stdn_cfname = None
         stdn_description = std_name.get('description')
         if stdn_description is None:
             sdict = {'standard_name': stdn_name}
             stdn_description = standard_name_to_description(sdict)
         # end if
         snl.write("* `{}`: {}\n".format(stdn_name, stdn_description))
-        # Should only be a type in the standard_name text
+        # Should only be type or cfname as subelements of standard_name
         for item in std_name:
             if item.tag == 'cfname':
-                continue
-            if item.tag == 'type':
+                snl.write(f"    * Equivalent CF name: {item.text}\n")
+            elif item.tag == 'type':
                 txt = item.text
                 units = item.get('units')
                 snl.write('    * `{}`: units = {}\n'.format(txt, units))

--- a/tools/write_standard_name_table.py
+++ b/tools/write_standard_name_table.py
@@ -178,6 +178,11 @@ def parse_section(snl, sec, level='##'):
             parse_section(snl, std_name, level + '#')
             continue
         stdn_name = std_name.get('name')
+        cfname_elem = std_name.find('cfname')
+        if cfname_elem is not None and cfname_elem.text is not None:
+            stdn_cfname = cfname_elem.text.strip()
+        else:
+            stdn_cfname = None
         stdn_description = std_name.get('description')
         if stdn_description is None:
             sdict = {'standard_name': stdn_name}
@@ -186,6 +191,8 @@ def parse_section(snl, sec, level='##'):
         snl.write("* `{}`: {}\n".format(stdn_name, stdn_description))
         # Should only be a type in the standard_name text
         for item in std_name:
+            if item.tag == 'cfname':
+                continue
             if item.tag == 'type':
                 txt = item.text
                 units = item.get('units')
@@ -231,6 +238,11 @@ def parse_section_for_yaml(section):
 
     for std_name in section.findall('standard_name'):
         stdn_name = std_name.get('name')
+        cfname_elem = std_name.find('cfname')
+        if cfname_elem is not None and cfname_elem.text is not None:
+            stdn_cfname = cfname_elem.text.strip()
+        else:
+            stdn_cfname = None
         stdn_description = std_name.get('description')
 
         if stdn_description is None:
@@ -241,6 +253,8 @@ def parse_section_for_yaml(section):
 
         std_name_data = OrderedDict()
         std_name_data['name'] = stdn_name
+        if stdn_cfname:
+            std_name_data['cfname'] = stdn_cfname
         std_name_data['description'] = stdn_description
         if std_type is not None:
             std_name_data['type'] = std_type.text

--- a/tools/write_standard_name_table.py
+++ b/tools/write_standard_name_table.py
@@ -187,7 +187,7 @@ def parse_section(snl, sec, level='##'):
         # Should only be type or cfname as subelements of standard_name
         for item in std_name:
             if item.tag == 'cfname':
-                snl.write(f"    * Equivalent CF name: {item.text}\n")
+                snl.write(f"    * `Equivalent CF name`: {item.text}\n")
             elif item.tag == 'type':
                 txt = item.text
                 units = item.get('units')

--- a/tools/write_standard_name_table.py
+++ b/tools/write_standard_name_table.py
@@ -187,7 +187,7 @@ def parse_section(snl, sec, level='##'):
         # Should only be type or cfname as subelements of standard_name
         for item in std_name:
             if item.tag == 'cfname':
-                snl.write(f"    * `Equivalent CF name`: {item.text}\n")
+                snl.write(f"    * Equivalent CF name: `{item.text}`\n")
             elif item.tag == 'type':
                 txt = item.text
                 units = item.get('units')


### PR DESCRIPTION
## Description
This PR updates the XML, schema file, and Metadata files to include and "Equivalent CF name" field, to make it easier for code bases such as JEDI that need to interface with both CF standard names and ESM standard names.

In this process I also found and removed some duplicate names, and moved some names to better sections

## Issues
Resolves #108

