### PR TITLE
Add additional allowed prefixes for booleans

### DIFF
--- a/StandardNamesRules.rst
+++ b/StandardNamesRules.rst
@@ -196,8 +196,8 @@ Terminology
    not valid standard name characters); e.g. ``number_density_of_plus_1_ionized_he``
 
 #. For control-oriented variables, if the variable is a Fortran logical,
-   use flag_for ``_X``. If it is any other data type, use control_for ``_X``. All flags
-   should be Fortran logicals.
+   use *flag_for*, *do*, or *is* as a prefix to the variable name, for example ``flag_for_X`` or ``do_Y`` or ``is_Z``. If it is any other data type, use the prefix *control_for*, for example ``control_for_XYZ``.
+
 
 #. **Disallowed terms:** A few terms are disallowed as standard name components for various reasons; mostly due to
    ambiguity.

--- a/StandardNamesRules.rst
+++ b/StandardNamesRules.rst
@@ -436,6 +436,8 @@ Prefixes
 | unfiltered
 | nonnegative
 | flag_for
+| do
+| is
 | control_for
 | number_of
 | index_of


### PR DESCRIPTION

## Description

This PR updates the set of allowed prefixes for booleans (e.g. variables that are of type `logical` in Fortran) to include `do` and `is` along with `flag_for`.  For example, with these rule changes the following three (made up) standard names would be allowed:

```
flag_for_deep_convection
do_deep_convective_transport
is_convective_cloud
```

whereas with the current rule set all three would need to start with `flag_for`:

```
flag_for_deep_convection
flag_for_deep_convective_transport
flag_for_convective_cloud
```

which may not be as clear.

## Issues

Addresses the "boolean indicator" discussion found in issue #101



