### PR TITLE
Improve definitions and usage of "surface" vs "surface_adjacent_layer" for wind variables, as well as "direction"

### DIFF
--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -601,10 +601,12 @@ Variables defining or relating to timing, dates, calendar, and related concepts
     * `real`: units = kg kg-1
 * `water_vapor_mixing_ratio_wrt_moist_air_two_timesteps_back`: Specific humidity (water vapor mass mixing ratio with respect to moist air) two timesteps back
     * `real`: units = kg kg-1
-* `wind_from_direction_at_surface`: Direction, from north, of wind speed closest to surface
+* `wind_from_direction_at_surface_adjacent_layer`: Direction (clockwise from north) wind vector is pointing away from, at the layer closest to surface.
     * `real`: units = degrees
-* `wind_speed_at_surface`: Scalar wind speed closest to surface
+* `wind_speed_at_surface_adjacent_layer`: Scalar wind speed at layer closest to surface
     * `real`: units = m s-1
+* `wind_to_direction_at_surface_adjacent_layer`: Direction (clockwise from north) wind vector is pointing towards at the layer closest to surface.
+    * `real`: units = degrees
 * `x_wind`: Horizontal wind in a direction perpendicular to y_wind
     * Equivalent CF name: `x_wind`
     * `real`: units = m s-1

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -470,7 +470,7 @@ Variables defining or relating to timing, dates, calendar, and related concepts
     * `real`: units = m s-1
 * `eastward_wind_at_10m`: Wind vector component at 10 meters above surface, positive when directed eastward
     * `real`: units = m s-1
-* `eastward_wind_at_surface`: Wind vector component closest to surface, positive when directed eastward
+* `eastward_wind_at_surface_adjacent_layer`: Wind vector component at layer closest to surface, positive when directed eastward
     * `real`: units = m s-1
 * `geopotential_at_interfaces`: Geopotential at interfaces
     * `real`: units = m2 s-2
@@ -530,7 +530,7 @@ Variables defining or relating to timing, dates, calendar, and related concepts
     * `real`: units = m s-1
 * `northward_wind_at_10m`: Wind vector component at 10 meters above surface, positive when directed northward
     * `real`: units = m s-1
-* `northward_wind_at_surface`: Wind vector component closest to surface, positive when directed northward
+* `northward_wind_at_surface_adjacent_layer`: Wind vector component at layer closest to surface, positive when directed northward
     * `real`: units = m s-1
 * `physics_state_due_to_dynamics`: Physics state due to dynamics
     * `ddt`: units = none
@@ -608,7 +608,7 @@ Variables defining or relating to timing, dates, calendar, and related concepts
 * `x_wind`: Horizontal wind in a direction perpendicular to y_wind
     * Equivalent CF name: `x_wind`
     * `real`: units = m s-1
-* `x_wind_at_surface_adjacent_layer`: X wind at surface adjacent layer
+* `x_wind_at_surface_adjacent_layer`: Wind vector component at layer closest to surface, perpendicular to y_wind
     * `real`: units = m s-1
 * `x_wind_of_new_state`: X wind of new state
     * `real`: units = m s-1
@@ -617,7 +617,7 @@ Variables defining or relating to timing, dates, calendar, and related concepts
 * `y_wind`: Horizontal wind in a direction perpendicular to x_wind
     * Equivalent CF name: `y_wind`
     * `real`: units = m s-1
-* `y_wind_at_surface_adjacent_layer`: Y wind at surface adjacent layer
+* `y_wind_at_surface_adjacent_layer`: Wind vector component at layer closest to surface, perpendicular to x_wind
     * `real`: units = m s-1
 * `y_wind_of_new_state`: Y wind of new state
     * `real`: units = m s-1

--- a/Metadata-standard-names.yaml
+++ b/Metadata-standard-names.yaml
@@ -1170,14 +1170,20 @@ section:
       moist air) two timesteps back
     type: real
     units: kg kg-1
-  - name: wind_from_direction_at_surface
-    description: Direction, from north, of wind speed closest to surface
+  - name: wind_from_direction_at_surface_adjacent_layer
+    description: Direction (clockwise from north) wind vector is pointing away from,
+      at the layer closest to surface.
     type: real
     units: degrees
-  - name: wind_speed_at_surface
-    description: Scalar wind speed closest to surface
+  - name: wind_speed_at_surface_adjacent_layer
+    description: Scalar wind speed at layer closest to surface
     type: real
     units: m s-1
+  - name: wind_to_direction_at_surface_adjacent_layer
+    description: Direction (clockwise from north) wind vector is pointing towards
+      at the layer closest to surface.
+    type: real
+    units: degrees
   - name: x_wind
     cfname: x_wind
     description: Horizontal wind in a direction perpendicular to y_wind

--- a/Metadata-standard-names.yaml
+++ b/Metadata-standard-names.yaml
@@ -901,9 +901,9 @@ section:
       eastward
     type: real
     units: m s-1
-  - name: eastward_wind_at_surface
-    description: Wind vector component closest to surface, positive when directed
-      eastward
+  - name: eastward_wind_at_surface_adjacent_layer
+    description: Wind vector component at layer closest to surface, positive when
+      directed eastward
     type: real
     units: m s-1
   - name: geopotential_at_interfaces
@@ -1020,9 +1020,9 @@ section:
       northward
     type: real
     units: m s-1
-  - name: northward_wind_at_surface
-    description: Wind vector component closest to surface, positive when directed
-      northward
+  - name: northward_wind_at_surface_adjacent_layer
+    description: Wind vector component at layer closest to surface, positive when
+      directed northward
     type: real
     units: m s-1
   - name: physics_state_due_to_dynamics
@@ -1184,7 +1184,8 @@ section:
     type: real
     units: m s-1
   - name: x_wind_at_surface_adjacent_layer
-    description: X wind at surface adjacent layer
+    description: Wind vector component at layer closest to surface, perpendicular
+      to y_wind
     type: real
     units: m s-1
   - name: x_wind_of_new_state
@@ -1201,7 +1202,8 @@ section:
     type: real
     units: m s-1
   - name: y_wind_at_surface_adjacent_layer
-    description: Y wind at surface adjacent layer
+    description: Wind vector component at layer closest to surface, perpendicular
+      to x_wind
     type: real
     units: m s-1
   - name: y_wind_of_new_state

--- a/StandardNamesRules.rst
+++ b/StandardNamesRules.rst
@@ -218,6 +218,7 @@ Terminology
    |                   |           |                                 | vegetation categories                                       |
    +-------------------+-----------+---------------------------------+-------------------------------------------------------------+
 
+#. The ``direction`` of a vector, unless noted otherwise, is the geographical bearing measured in the positive clockwise direction from due north. For example, ``wind_to_direction = 90`` is the same as ``wind_from_direction = 270``, meaning wind blowing towards the east.
 
 #. **Disallowed terms:** A few terms are disallowed as standard name components for various reasons; mostly due to
    ambiguity.

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -669,7 +669,7 @@
     <standard_name name="eastward_wind_at_10m" description="Wind vector component at 10 meters above surface, positive when directed eastward">
       <type units="m s-1">real</type>
     </standard_name>
-    <standard_name name="eastward_wind_at_surface" description="Wind vector component closest to surface, positive when directed eastward">
+    <standard_name name="eastward_wind_at_surface_adjacent_layer" description="Wind vector component at layer closest to surface, positive when directed eastward">
       <type units="m s-1">real</type>
     </standard_name>
     <standard_name name="geopotential_at_interfaces">
@@ -757,7 +757,7 @@
     <standard_name name="northward_wind_at_10m" description="Wind vector component at 10 meters above surface, positive when directed northward">
       <type units="m s-1">real</type>
     </standard_name>
-    <standard_name name="northward_wind_at_surface" description="Wind vector component closest to surface, positive when directed northward">
+    <standard_name name="northward_wind_at_surface_adjacent_layer" description="Wind vector component at layer closest to surface, positive when directed northward">
       <type units="m s-1">real</type>
     </standard_name>
     <standard_name name="physics_state_due_to_dynamics">
@@ -872,7 +872,7 @@
       <cfname>x_wind</cfname>
       <type units="m s-1">real</type>
     </standard_name>
-    <standard_name name="x_wind_at_surface_adjacent_layer">
+    <standard_name name="x_wind_at_surface_adjacent_layer" description="Wind vector component at layer closest to surface, perpendicular to y_wind">
       <type units="m s-1">real</type>
     </standard_name>
     <standard_name name="x_wind_of_new_state">
@@ -885,7 +885,7 @@
       <cfname>y_wind</cfname>
       <type units="m s-1">real</type>
     </standard_name>
-    <standard_name name="y_wind_at_surface_adjacent_layer">
+    <standard_name name="y_wind_at_surface_adjacent_layer" description="Wind vector component at layer closest to surface, perpendicular to x_wind">
       <type units="m s-1">real</type>
     </standard_name>
     <standard_name name="y_wind_of_new_state">

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -862,11 +862,14 @@
     <standard_name name="water_vapor_mixing_ratio_wrt_moist_air_two_timesteps_back" description="Specific humidity (water vapor mass mixing ratio with respect to moist air) two timesteps back">
       <type units="kg kg-1">real</type>
     </standard_name>
-    <standard_name name="wind_from_direction_at_surface" description="Direction, from north, of wind speed closest to surface">
+    <standard_name name="wind_from_direction_at_surface_adjacent_layer" description="Direction (clockwise from north) wind vector is pointing away from, at the layer closest to surface.">
       <type units="degrees">real</type>
     </standard_name>
-    <standard_name name="wind_speed_at_surface" description="Scalar wind speed closest to surface">
+    <standard_name name="wind_speed_at_surface_adjacent_layer" description="Scalar wind speed at layer closest to surface">
       <type units="m s-1">real</type>
+    </standard_name>
+    <standard_name name="wind_to_direction_at_surface_adjacent_layer" description="Direction (clockwise from north) wind vector is pointing towards at the layer closest to surface.">
+      <type units="degrees">real</type>
     </standard_name>
     <standard_name name="x_wind" description="Horizontal wind in a direction perpendicular to y_wind">
       <cfname>x_wind</cfname>


### PR DESCRIPTION
## Description
As discussed in issues #151 and #153, there are shortcomings in both the names and definitions surrounding near-surface wind. This PR implements the changes discussed in those issues:

 - `wind_at_surface` variables are now `wind_at_surface_adjacent_layer`
 - We now have `wind_to_direction` in addition to `wind_from_direction`
 - `direction` is given a definition in the rules

## Issues
Resolves #151, #153  

